### PR TITLE
feat(ci): add ISO promotion workflow from testing to production

### DIFF
--- a/.github/workflows/promote-iso.yml
+++ b/.github/workflows/promote-iso.yml
@@ -1,0 +1,102 @@
+---
+name: Promote ISOs to Production
+on:
+  workflow_dispatch:
+    inputs:
+      variant:
+        description: 'Which ISOs to promote'
+        required: true
+        type: choice
+        options:
+          - stable
+          - lts
+          - all
+        default: stable
+      dry_run:
+        description: 'Run in dry-run mode (preview changes without copying)'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  promote:
+    name: Promote ISOs from Testing to Production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # defined here, these apply to ALL steps in this job
+    env:
+      # Test Bucket Config (Source) - using same R2 credentials as build workflow
+      RCLONE_CONFIG_R2_TEST_TYPE: s3
+      RCLONE_CONFIG_R2_TEST_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_TEST_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID_2025 }}
+      RCLONE_CONFIG_R2_TEST_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY_2025 }}
+      RCLONE_CONFIG_R2_TEST_REGION: auto
+      RCLONE_CONFIG_R2_TEST_ENDPOINT: ${{ secrets.R2_ENDPOINT_2025 }}
+
+      # Production Bucket Config (Destination) - using same R2 credentials
+      RCLONE_CONFIG_R2_PROD_TYPE: s3
+      RCLONE_CONFIG_R2_PROD_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_PROD_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID_2025 }}
+      RCLONE_CONFIG_R2_PROD_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY_2025 }}
+      RCLONE_CONFIG_R2_PROD_REGION: auto
+      RCLONE_CONFIG_R2_PROD_ENDPOINT: ${{ secrets.R2_ENDPOINT_2025 }}
+
+    steps:
+      - name: Install rclone
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rclone
+
+      - name: Set file filter
+        id: filter
+        run: |
+          case "${{ inputs.variant }}" in
+            "stable")
+              # Stable: GTS and Stable ISOs only (bluefin-stable-*, bluefin-gts-*)
+              echo "filter=--include *-stable-*.iso* --include *-gts-*.iso*" >> $GITHUB_OUTPUT
+              echo "Promoting Stable variant ISOs (GTS and Stable)"
+              ;;
+            "lts")
+              # LTS: LTS, LTS-HWE, and GDX ISOs (bluefin-lts-*, bluefin-lts-hwe-*, bluefin-dx-lts-*)
+              echo "filter=--include *-lts-*.iso* --include *-lts-hwe-*.iso* --include *-dx-lts-*.iso*" >> $GITHUB_OUTPUT
+              echo "Promoting LTS variant ISOs (LTS, LTS-HWE, and GDX)"
+              ;;
+            "all")
+              # All: All ISO and CHECKSUM files
+              echo "filter=--include *.iso --include *.iso-CHECKSUM" >> $GITHUB_OUTPUT
+              echo "Promoting ALL ISOs"
+              ;;
+          esac
+
+      - name: List files in Testing bucket
+        run: |
+          echo "Files in Testing bucket (matching filter):"
+          rclone ls R2_TEST:testing ${{ steps.filter.outputs.filter }}
+
+      - name: Promote ISOs (Dry Run)
+        if: inputs.dry_run == true
+        run: |
+          echo "Running in DRY RUN mode - no files will be copied"
+          echo "Variant: ${{ inputs.variant }}"
+          rclone sync R2_TEST:testing R2_PROD:prodtest \
+            ${{ steps.filter.outputs.filter }} \
+            --dry-run \
+            --verbose
+
+      - name: Promote ISOs (Production)
+        if: inputs.dry_run == false
+        run: |
+          echo "Promoting ISOs from Testing to Production"
+          echo "Variant: ${{ inputs.variant }}"
+          rclone sync R2_TEST:testing R2_PROD:prodtest \
+            ${{ steps.filter.outputs.filter }} \
+            --verbose \
+            --progress
+
+      - name: Verify promotion
+        if: inputs.dry_run == false
+        run: |
+          echo "Files in Production bucket after promotion (matching filter):"
+          rclone ls R2_PROD:prodtest ${{ steps.filter.outputs.filter }}


### PR DESCRIPTION
Add workflow to promote ISOs from `testing` to `prodtest` bucket with controlled release process and variant selection.

## Implementation

- **New workflow**: `.github/workflows/promote-iso.yml`
  - Manual trigger only via `workflow_dispatch`
  - Dry-run mode enabled by default for safe preview
  - Variant selection: `stable`, `lts`, or `all` ISOs
  - Uses `rclone sync` to copy `.iso` and `.iso-CHECKSUM` files
  - Source: `testing` bucket (automatic builds)
  - Destination: `prodtest` bucket (production releases)

## Workflow Steps

1. Install rclone
2. Set file filter based on variant selection
3. List files in testing bucket (with filter)
4. Execute sync (dry-run or production based on input)
5. Verify production bucket contents post-promotion

## Variant Options

| Variant | ISOs Promoted | Use Case |
|---------|--------------|----------|
| **stable** | • GTS ISOs<br/>• Stable ISOs | Regular stable release cycle |
| **lts** | • LTS ISOs<br/>• LTS-HWE ISOs<br/>• GDX ISOs | LTS release cycle |
| **all** | • All ISOs<br/>• All checksums | Major releases or bulk updates |

## Usage

1. Navigate to **Actions → Promote ISOs to Production**
2. Click **"Run workflow"**
3. Select **variant** and configure **dry_run**:
   - `dry_run: true` - Preview changes (default)
   - `dry_run: false` - Execute promotion
4. Always preview with dry-run before promoting

## Documentation

- Added **ISO Release Pipeline** section to README.md with visual diagram
- Documented promotion workflow steps
- Included variant selection details table
- Added example workflow scenario

## Important Notes

- **Dry run is enabled by default** - Always preview before promoting
- **rclone sync is used** - Files in testing will mirror to production
- **Selective promotion** - Promote stable and LTS independently
- **Checksums included** - `.iso-CHECKSUM` files are automatically included

---

Adapted from inffy/iso#2 with the following changes:
- Bucket names: `aurora-dl-test` → `testing`, `aurora-dl` → `prodtest`
- Secrets: Unified to use `R2_*_2025` for both source and destination
- Added variant selection feature for selective ISO promotion
- Included GDX ISOs in LTS variant promotion

---

**Assisted-by**: Claude 3.5 Sonnet via GitHub Copilot