### PR TITLE
fix(ci): resolve anaconda-webui package conflict after bluefin PR #4072

### DIFF
--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -49,7 +49,7 @@ systemctl disable brew-setup.service
 systemctl disable rpm-ostreed-automatic.timer
 systemctl disable uupd.timer
 systemctl disable ublue-system-setup.service
-systemctl disable ublue-guest-user.service
+systemctl disable ublue-guest-user.service || true
 systemctl disable check-sb-key.service
 systemctl disable flatpak-preinstall.service
 systemctl --global disable ublue-flatpak-manager.service
@@ -74,7 +74,7 @@ if [[ "$IMAGE_TAG" =~ lts ]]; then
 elif [[ "$(rpm -E %fedora)" -ge 42 ]]; then
     SPECS+=("anaconda-webui")
 fi
-dnf install -y "${SPECS[@]}"
+dnf install -y --allowerasing "${SPECS[@]}"
 
 dnf config-manager --set-disabled centos-hyperscale &>/dev/null || true
 


### PR DESCRIPTION
Add --allowerasing to dnf install to handle the interaction between Bluefin's fedora-logos fix (ublue-os/bluefin#4072) and anaconda-webui installation.

Root cause:
- ublue-os/bluefin#4072 (merged Jan 20) keeps fedora-logos in RPM database
- This fixed ISO branding issues (projectbluefin/iso#21)
- But anaconda-webui now sees fedora-logos in RPM DB and requires it
- Actual files on disk are generic-logos (conflict)
- dnf install fails without --allowerasing

Also make ublue-guest-user.service disable non-fatal (service may not exist).

Fixes Stable ISO build failures since Feb 1, 2026.

Related: bluefin-common-e5l
Upstream fix: ublue-os/bluefin#4072

Assisted-by: Claude 3.5 Sonnet via GitHub Copilot