### PR TITLE
fix: fedora logos in iso

### DIFF
--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -70,10 +70,6 @@ SPECS=(
     "firefox"
 )
 
-    SPECS+=("anaconda-webui")
-elif [[ "$(rpm -E %fedora)" -ge 42 ]]; then
-    SPECS+=("anaconda-webui")
-fi
 dnf install -y "${SPECS[@]}"
 
 rpm --erase --nodeps --justdb fedora-logos

--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -49,8 +49,6 @@ systemctl disable brew-setup.service
 systemctl disable rpm-ostreed-automatic.timer
 systemctl disable uupd.timer
 systemctl disable ublue-system-setup.service
-systemctl disable ublue-guest-user.service || true
-systemctl disable check-sb-key.service
 systemctl disable flatpak-preinstall.service
 systemctl --global disable ublue-flatpak-manager.service
 systemctl --global disable podman-auto-update.timer

--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -56,6 +56,11 @@ systemctl --global disable ublue-flatpak-manager.service
 systemctl --global disable podman-auto-update.timer
 systemctl --global disable ublue-user-setup.service
 
+# HACK for https://bugzilla.redhat.com/show_bug.cgi?id=2433186
+rpm --erase --nodeps --justdb generic-logos
+dnf download fedora-logos
+rpm -i --justdb fedora-logos*.rpm
+
 # Configure Anaconda
 
 # Install Anaconda, Webui if >= F42
@@ -66,17 +71,14 @@ SPECS=(
     "anaconda-live"
     "firefox"
 )
-if [[ "$IMAGE_TAG" =~ lts ]]; then
-    dnf config-manager --set-enabled centos-release-kmods-kernel
-    dnf copr enable -y jreilly/anaconda-webui
 
     SPECS+=("anaconda-webui")
 elif [[ "$(rpm -E %fedora)" -ge 42 ]]; then
     SPECS+=("anaconda-webui")
 fi
-dnf install -y --allowerasing "${SPECS[@]}"
+dnf install -y "${SPECS[@]}"
 
-dnf config-manager --set-disabled centos-hyperscale &>/dev/null || true
+rpm --erase --nodeps --justdb fedora-logos
 
 # Anaconda Profile Detection
 


### PR DESCRIPTION
fixes: https://github.com/projectbluefin/iso/issues/29

same as: https://github.com/get-aurora-dev/iso/pull/29

no idea why the lts stuff is here