### PR TITLE
chore: remove space saving actions

### DIFF
--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -127,20 +127,6 @@ jobs:
           sudo apt install -y \
             podman
 
-      - name: Maximize build space (remove-software)
-        if: matrix.platform != 'arm64'
-        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
-        with:
-          remove-codeql: true
-
-      - name: Maximize build space
-        uses: ublue-os/container-storage-action@911baca08baf30c8654933e9e9723cb399892140
-        continue-on-error: true
-        with:
-          target-dir: /var/lib/containers
-          mount-opts: compress-force=zstd:2
-          loopback-free: 0.9
-
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:


### PR DESCRIPTION
github runners have more disk space now, we probably don't need this anymore