### PR TITLE
fix(ci): correct build-iso-all cron schedule to run monthly

### DIFF
--- a/.github/workflows/build-iso-all.yml
+++ b/.github/workflows/build-iso-all.yml
@@ -23,7 +23,7 @@ on:
         type: boolean
         default: true
   schedule:
-    - cron: "0 3 1 1" # Push to testing bucket on the first of the month at 03:00 on Tuesdays - 2h after Bluefin publishes weekly builds.
+    - cron: "0 3 1 * *" # Push to testing bucket on the first of the month at 03:00 UTC - 2h after Bluefin publishes monthly builds.
 
 jobs:
   build-iso-lts:


### PR DESCRIPTION
## Problem

The cron schedule `"0 3 1 1"` in `build-iso-all.yml` only fires on January 1st that also falls on a Tuesday — effectively never.

## Fix

Changed to `"0 3 1 * *"` so it runs on the 1st of every month at 03:00 UTC, consistent with the schedule in `build-iso-stable.yml`.

Closes https://github.com/ublue-os/bluefin/discussions/4262 (partial — the stale production ISOs and missing torrent files still need a manual `promote-iso` run)