### PR TITLE
ci(iso): add weekly lts-hwe-testing iso build

### DIFF
--- a/.github/workflows/build-iso-lts-hwe-testing.yml
+++ b/.github/workflows/build-iso-lts-hwe-testing.yml
@@ -1,0 +1,30 @@
+---
+name: Build LTS-HWE Testing ISOs
+# This workflow ONLY builds LTS-HWE testing ISOs
+# Builds: 2 LTS-HWE testing ISOs
+#   - amd64 x main
+#   - arm64 x main
+on:
+  workflow_dispatch:
+    inputs:
+      upload_artifacts:
+        description: 'Upload ISOs as job artifacts'
+        type: boolean
+        default: false
+      upload_r2:
+        description: 'Upload ISOs to Cloudflare R2'
+        type: boolean
+        default: true
+  schedule:
+    - cron: '17 6 * * 1'  # Every Monday at 06:17 UTC
+
+jobs:
+  build-iso-lts-hwe-testing:
+    name: Build LTS-HWE Testing ISOs
+    uses: ./.github/workflows/reusable-build-iso-anaconda.yml
+    secrets: inherit
+    with:
+      image_version: lts-hwe
+      image_tag: lts-hwe-testing
+      upload_artifacts: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_artifacts || false }}
+      upload_r2: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_r2 || true }}

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -149,7 +149,8 @@ jobs:
           # Standard variants use the Just recipe to determine image name
           image_name=$(just image_name "bluefin" "${{ matrix.image_version}}" "${{ matrix.flavor}}")
           image_ref="${IMAGE_REGISTRY}/${image_name}"
-          artifact_format="$image_name-${{ matrix.image_version }}-$(uname -m)"
+          effective_tag="${{ inputs.image_tag || matrix.image_version }}"
+          artifact_format="$image_name-${effective_tag}-$(uname -m)"
           KARGS="NONE"
           echo "image_ref=$image_ref" >> "${GITHUB_OUTPUT}"
           echo "artifact_format=$artifact_format" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Schedule a dedicated lts-hwe-testing workflow and propagate effective image tags into ISO artifact naming so testing outputs include -testing in filenames.

This doesn't touch anything production related.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot