### PR TITLE
ci(iso): harden testing/production isolation across build and promote…

### DIFF
--- a/.github/workflows/build-iso-all.yml
+++ b/.github/workflows/build-iso-all.yml
@@ -3,9 +3,8 @@ name: Build All ISOs
 # Orchestrator workflow that calls ALL individual ISO build workflows
 # Builds ALL production ISOs with production tags only
 #
-# For testing tags (-testing), use individual variant workflows:
-#   - build-iso-lts.yml → select lts-testing
-#   - build-iso-lts-hwe.yml → select lts-hwe-testing
+# For testing tags (-testing), use the dedicated testing workflow:
+#   - build-iso-lts-hwe-testing.yml (the ONLY authorized workflow for testing tags)
 #
 # Total: 8 production ISOs across all variants:
 #   - build-iso-stable   → 2 Stable ISOs (amd64 × main, amd64 × nvidia-open)
@@ -32,9 +31,9 @@ jobs:
     secrets: inherit
     with:
       image_version: lts  # Strictly LTS only
-      image_tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || 'lts' }}
+      image_tag: lts  # Hardcoded: build-iso-all.yml only builds production tags
       upload_artifacts: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_artifacts || false }}
-      upload_r2: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_r2 || true }}
+      upload_r2: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_r2 }}
 
   build-iso-lts-hwe:
     name: Build LTS-HWE ISOs
@@ -44,7 +43,7 @@ jobs:
       image_version: lts-hwe  # Strictly LTS-HWE only
       image_tag: lts-hwe
       upload_artifacts: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_artifacts || false }}
-      upload_r2: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_r2 || true }}
+      upload_r2: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_r2 }}
 
   build-iso-stable:
     name: Build Stable ISOs
@@ -54,4 +53,4 @@ jobs:
       image_version: stable  # Strictly Stable only
       image_tag: stable
       upload_artifacts: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_artifacts || false }}
-      upload_r2: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_r2 || true }}
+      upload_r2: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_r2 }}

--- a/.github/workflows/build-iso-lts-hwe-testing.yml
+++ b/.github/workflows/build-iso-lts-hwe-testing.yml
@@ -1,6 +1,10 @@
 ---
 name: Build LTS-HWE Testing ISOs
-# This workflow ONLY builds LTS-HWE testing ISOs
+# This is the ONLY authorized workflow for building lts-hwe-testing ISOs.
+# Testing tags (lts-hwe-testing) must NOT be used in build-iso-lts-hwe.yml or
+# build-iso-all.yml — those workflows are for production tags only.
+# Note: choice-input removal enforces this at the UI/CLI level; direct API
+# callers must follow this policy by convention.
 # Builds: 2 LTS-HWE testing ISOs
 #   - amd64 x main
 #   - arm64 x main
@@ -27,4 +31,4 @@ jobs:
       image_version: lts-hwe
       image_tag: lts-hwe-testing
       upload_artifacts: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_artifacts || false }}
-      upload_r2: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_r2 || true }}
+      upload_r2: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_r2 }}

--- a/.github/workflows/build-iso-lts-hwe.yml
+++ b/.github/workflows/build-iso-lts-hwe.yml
@@ -8,11 +8,10 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag to build from'
+        description: 'Image tag to build from (production only; for lts-hwe-testing use build-iso-lts-hwe-testing.yml)'
         type: choice
         options:
           - lts-hwe
-          - lts-hwe-testing
         default: lts-hwe
       upload_artifacts:
         description: 'Upload ISOs as job artifacts'
@@ -34,4 +33,4 @@ jobs:
       image_version: lts-hwe  # Strictly builds LTS-HWE ISOs only
       image_tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || 'lts-hwe' }}
       upload_artifacts: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_artifacts || false }}
-      upload_r2: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_r2 || true }}
+      upload_r2: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_r2 }}

--- a/.github/workflows/build-iso-lts.yml
+++ b/.github/workflows/build-iso-lts.yml
@@ -10,11 +10,10 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag to build from'
+        description: 'Image tag to build from (production only; no authorized workflow exists for lts-testing)'
         type: choice
         options:
           - lts
-          - lts-testing
         default: lts
       upload_artifacts:
         description: 'Upload ISOs as job artifacts'
@@ -36,4 +35,4 @@ jobs:
       image_version: lts  # Strictly builds LTS ISOs only
       image_tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || 'lts' }}
       upload_artifacts: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_artifacts || false }}
-      upload_r2: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_r2 || true }}
+      upload_r2: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_r2 }}

--- a/.github/workflows/promote-iso.yml
+++ b/.github/workflows/promote-iso.yml
@@ -108,15 +108,27 @@ jobs:
             exit 1
           fi
 
+          # Build an rclone filter file for this variant.
+          #
+          # WHY the '- *-testing-*' rule is first in every variant block:
+          # Testing ISOs (e.g. bluefin-lts-hwe-testing-x86_64.iso) share a naming
+          # prefix with their production counterparts. Without an explicit exclusion,
+          # the production include rules below would match them:
+          #   '+ *-lts-hwe-*.iso*' matches both lts-hwe AND lts-hwe-testing files.
+          # Placing '- *-testing-*' first ensures rclone discards testing artifacts
+          # before evaluating the production include rules, regardless of what files
+          # happen to be present in the testing bucket.
           FILTER_FILE="${RUNNER_TEMP}/rclone-filter-${{ inputs.variant }}.txt"
           case "${{ inputs.variant }}" in
             stable)
               printf '%s\n' \
+                '- *-testing-*' \
                 '+ *-stable-*.iso*' \
                 '- *' > "${FILTER_FILE}"
               ;;
             lts)
               printf '%s\n' \
+                '- *-testing-*' \
                 '- *-lts-hwe-*.iso*' \
                 '+ *-dx-lts-*.iso*' \
                 '+ *-lts-*.iso*' \
@@ -124,6 +136,7 @@ jobs:
               ;;
             lts-hwe)
               printf '%s\n' \
+                '- *-testing-*' \
                 '+ *-lts-hwe-*.iso*' \
                 '- *' > "${FILTER_FILE}"
               ;;
@@ -139,6 +152,13 @@ jobs:
 
           SOURCE_VARIANT_ASSET_COUNT=0
           while IFS= read -r asset_name; do
+            # Exclude testing artifacts from the production asset count.
+            # A prerelease may contain both production and testing torrents
+            # (e.g. from a mixed build run). Only production assets count
+            # toward the minimum required for a valid promotion.
+            case "${asset_name}" in
+              *-testing-*) continue ;;
+            esac
             case "${{ inputs.variant }}" in
               stable)
                 case "${asset_name}" in
@@ -274,6 +294,14 @@ jobs:
 
           for file in "${RAW_DIR}"/*; do
             name=$(basename "${file}")
+            # Exclude testing artifacts from the production GitHub release.
+            # A prerelease may contain both production and testing torrents
+            # (e.g. lts-hwe and lts-hwe-testing from the same build window).
+            # The production include rules below would otherwise match testing
+            # filenames by prefix — this guard is the last line of defense.
+            case "${name}" in
+              *-testing-*) continue ;;
+            esac
             case "${{ inputs.variant }}" in
               stable)
                 case "${name}" in


### PR DESCRIPTION
I'm explicitly splitting the testing and non-testing workflows. 

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot