### PR TITLE
fix(iso): remove ublue-flatpak-manager.service disable

### DIFF
--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -50,7 +50,6 @@ systemctl disable rpm-ostreed-automatic.timer
 systemctl disable uupd.timer
 systemctl disable ublue-system-setup.service
 systemctl disable flatpak-preinstall.service
-systemctl --global disable ublue-flatpak-manager.service
 systemctl --global disable podman-auto-update.timer
 systemctl --global disable ublue-user-setup.service
 

--- a/iso_files/configure_lts_iso_anaconda.sh
+++ b/iso_files/configure_lts_iso_anaconda.sh
@@ -43,7 +43,6 @@ systemctl disable uupd.timer
 systemctl disable ublue-system-setup.service
 # systemctl disable ublue-guest-user.service
 # systemctl disable check-sb-key.service
-# systemctl --global disable ublue-flatpak-manager.service
 systemctl --global disable podman-auto-update.timer
 systemctl --global disable ublue-user-setup.service
 


### PR DESCRIPTION
## Problem

Both stable ISO builds are failing at `hook-post-rootfs`:

```
Failed to disable unit: Unit ublue-flatpak-manager.service does not exist
error: recipe `hook-post-rootfs` failed with exit code 1
```

`systemctl --global disable` exits non-zero when the unit doesn't exist, aborting the script under `set -eoux pipefail`.

## Root cause

`ublue-flatpak-manager.service` no longer exists in the Bluefin image. Verified: not present in `ublue-os/packages`, `ublue-os/main`, `projectbluefin/common`, or the local build rootfs.

## Fix

Remove the dead `systemctl --global disable ublue-flatpak-manager.service` line from both hook scripts.

Fixes: https://github.com/projectbluefin/iso/actions/runs/25689630583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed service disablement configuration from installation scripts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/iso/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->