### PR TITLE
chore: remove logo hacks

### DIFF
--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -53,11 +53,6 @@ systemctl disable flatpak-preinstall.service
 systemctl --global disable podman-auto-update.timer
 systemctl --global disable ublue-user-setup.service
 
-# HACK for https://bugzilla.redhat.com/show_bug.cgi?id=2433186
-rpm --erase --nodeps --justdb generic-logos
-dnf download fedora-logos
-rpm -i --justdb fedora-logos*.rpm
-
 # Configure Anaconda
 
 # Install Anaconda, Webui if >= F42
@@ -70,8 +65,6 @@ SPECS=(
 )
 
 dnf install -y "${SPECS[@]}"
-
-rpm --erase --nodeps --justdb fedora-logos
 
 # Anaconda Profile Detection
 


### PR DESCRIPTION
Fedora 44 ships the ananconda version with the fix merged so we can get rid of this nastiness

See: https://github.com/rhinstaller/anaconda-webui/commit/fe65289689fd49f1a73c4b06e1b8dff8998ed6eb
See: https://bugzilla.redhat.com/show_bug.cgi?id=2433186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary RPM package manipulation operations from ISO configuration setup. The legacy code block performing intermediate logo package registration steps has been eliminated, while all core system configuration, profile generation, key enrollment, and package installation processes remain unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/iso/pull/54)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->