### PR TITLE
docs: clarify LTS breakage affects all flavors including GDX (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Workflows and configuration files needed to build bootable Bluefin ISOs for inst
 ## ⚠️ LTS ISO Status: DISABLED
 
 **LTS (non-HWE) ISOs are currently broken.** Anaconda does not work correctly on
-the LTS base image. The `build-iso-lts.yml` workflow has no schedule and will not
-fire automatically. Working LTS ISOs remain in the production bucket from before
-this breakage and must not be overwritten.
+the LTS base image. This affects **all LTS flavors** including `main` and `gdx`
+(Gnome Developer Experience). The `build-iso-lts.yml` workflow has no schedule and
+will not fire automatically. Working LTS ISOs remain in the production bucket from
+before this breakage and must not be overwritten.
+
+**Known symptom:** The installer completes normally but account creation fails
+on first boot, leaving the system in an unusable state (#51).
 
 **Do not** run `promote-iso.yml` with `variant: lts` or `variant: all` — both
 patterns match `*-lts-*.iso*` filenames and would overwrite production ISOs.


### PR DESCRIPTION
## Summary

Closes #51

The existing LTS warning didn't explicitly mention that the GDX (Gnome Developer Experience) flavor is also affected. A user reported installing the GDX LTS ISO and hitting account creation failure — the same documented Anaconda/LTS breakage.

## Changes

- Added explicit mention that ALL LTS flavors (main and gdx) are affected
- Added the known symptom (account creation failure on first boot)
- Added reference to issue #51 as a user-confirmed case