### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Default: any one maintainer approves
+* @castrojo @p5 @m2Giles @tulilirockz
+
+# Sensitive paths — require maintainer review
+.github/workflows/  @castrojo @p5 @m2Giles @tulilirockz @hanthor @renner0e
+Justfile            @castrojo @p5 @m2Giles @tulilirockz @hanthor @renner0e
+iso_files/          @castrojo @p5 @m2Giles @tulilirockz @hanthor @renner0e
+hack/               @castrojo @p5 @m2Giles @tulilirockz @hanthor @renner0e
+
+# BEGIN TRIAGERS — managed by projectbluefin/common, do not edit manually
+# docs/**  @handle1 @handle2
+# *.md     @handle1 @handle2
+# END TRIAGERS


### PR DESCRIPTION
Surfaced by the 2026-06-10 drift-refresh of [`projectbluefin/common`'s automation audit](https://github.com/projectbluefin/common/blob/main/docs/factory/automation-audit/README.md). Tracks projectbluefin/common#589.

## Problem

`projectbluefin/iso` ships without `.github/CODEOWNERS`. Auto-review-request routing falls back to whoever last touched the file \u2014 non-deterministic. Inconsistent with the bluefin/bluefin-lts/dakota/common/actions pattern (10\u201315-line CODEOWNERS each).

## Change

Add `.github/CODEOWNERS` mirroring the shape used in `bluefin`/`dakota`/`actions`:

- Default maintainer set: the canonical factory four (@castrojo @p5 @m2Giles @tulilirockz)
- Sensitive paths (`.github/workflows/`, `Justfile`, `iso_files/`, `hack/`) additionally include @hanthor and @renner0e \u2014 confirmed as the active iso-specific contributors via 30-commit recent-committers API check
- `BEGIN TRIAGERS` / `END TRIAGERS` sentinel left as a commented stub so projectbluefin/common automation can drop in triagers later

## Verification

- [x] CODEOWNERS syntax matches dakota/bluefin pattern
- [ ] CI green on this PR

Closes projectbluefin/common#589 (paired with sister PR for bonedigger: projectbluefin/bonedigger#22).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration for repository maintenance and review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->