### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Default: any one maintainer approves
+* @projectbluefin/maintainers
+
+# Sensitive paths — require maintainer review
+.github/workflows/  @projectbluefin/maintainers
+Justfile            @projectbluefin/maintainers
+iso_files/          @projectbluefin/maintainers
+hack/               @projectbluefin/maintainers
+
+# BEGIN TRIAGERS — managed by projectbluefin/common, do not edit manually
+# docs/**  @handle1 @handle2
+# *.md     @handle1 @handle2
+# END TRIAGERS


### PR DESCRIPTION
Surfaced by the 2026-06-10 drift-refresh of [`projectbluefin/common`'s automation audit](https://github.com/projectbluefin/common/blob/main/docs/factory/automation-audit/README.md). Tracks projectbluefin/common#589.

Replaces closed #59 (which used individual handles instead of the team).

## Problem

`projectbluefin/iso` ships without `.github/CODEOWNERS`. Auto-review-request routing falls back to whoever last touched the file \u2014 non-deterministic.

## Change

Add `.github/CODEOWNERS` using the `@projectbluefin/maintainers` team handle as the default owner. This mirrors the team-handle pattern used in common's TRIAGERS line and means team-membership changes auto-propagate to CODEOWNERS without further PRs.

- Default: `* @projectbluefin/maintainers`
- Sensitive paths (`.github/workflows/`, `Justfile`, `iso_files/`, `hack/`) also gated on `@projectbluefin/maintainers`
- `BEGIN TRIAGERS` / `END TRIAGERS` sentinel left as a commented stub so projectbluefin/common automation can drop in triagers later

## Verification

- [x] CODEOWNERS uses team handle (mirrors common pattern)
- [ ] CI green on this PR

Closes projectbluefin/common#589 (paired with sister PR for bonedigger: projectbluefin/bonedigger#22).