### PR TITLE
test(iso): add artifact-backed stable installer E2E

### DIFF
--- a/.github/workflows/iso-e2e-test.yml
+++ b/.github/workflows/iso-e2e-test.yml
@@ -1,0 +1,145 @@
+name: ISO E2E Test
+
+run-name: >-
+  ISO E2E validation for ${{ github.event.client_payload.release_tag || inputs.release_tag || 'manual' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      iso_url:
+        description: 'HTTPS URL for the ISO to test'
+        required: false
+        type: string
+      source_run_id:
+        description: 'Workflow run ID containing an ISO artifact'
+        required: false
+        type: string
+      artifact_name:
+        description: 'Optional ISO artifact name from source_run_id'
+        required: false
+        type: string
+      iso_path:
+        description: 'Path to a checked-in ISO in this repository'
+        required: false
+        type: string
+      release_tag:
+        description: 'Release tag used for this E2E run'
+        required: false
+        type: string
+      variant:
+        description: 'Variant being validated'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      iso_url:
+        description: 'HTTPS URL for the ISO to test'
+        required: false
+        type: string
+        default: ''
+      source_run_id:
+        description: 'Workflow run ID containing an ISO artifact'
+        required: false
+        type: string
+        default: ''
+      artifact_name:
+        description: 'Optional ISO artifact name from source_run_id'
+        required: false
+        type: string
+        default: ''
+      iso_path:
+        description: 'Path to an ISO available after checkout'
+        required: false
+        type: string
+        default: ''
+      release_tag:
+        description: 'Release tag used for this E2E run'
+        required: false
+        type: string
+        default: ''
+      variant:
+        description: 'Variant being validated'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install QEMU and tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes qemu-system-x86 qemu-utils xorriso ffmpeg
+
+      - name: Resolve ISO input
+        id: context
+        env:
+          INPUT_ISO_URL: ${{ inputs.iso_url }}
+          INPUT_SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          INPUT_ISO_PATH: ${{ inputs.iso_path }}
+          DISPATCH_ISO_URL: ${{ github.event.client_payload.iso_url }}
+          DISPATCH_SOURCE_RUN_ID: ${{ github.event.client_payload.source_run_id }}
+          DISPATCH_ISO_PATH: ${{ github.event.client_payload.iso_path }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          iso_url="${DISPATCH_ISO_URL:-${INPUT_ISO_URL}}"
+          source_run_id="${DISPATCH_SOURCE_RUN_ID:-${INPUT_SOURCE_RUN_ID}}"
+          iso_path="${DISPATCH_ISO_PATH:-${INPUT_ISO_PATH}}"
+          if [[ -n "$iso_url" ]]; then
+            mkdir -p e2e-input
+            curl --fail --location --retry 3 --retry-all-errors --output e2e-input/source.iso "$iso_url"
+            iso_path="$PWD/e2e-input/source.iso"
+          elif [[ -n "$source_run_id" ]]; then
+            mkdir -p e2e-input
+            artifact_name="${{ github.event.client_payload.artifact_name || inputs.artifact_name || '' }}"
+            if [[ -n "$artifact_name" ]]; then
+              gh run download "$source_run_id" --name "$artifact_name" --dir e2e-input
+            else
+              gh run download "$source_run_id" --pattern "iso-${source_run_id}-*" --dir e2e-input
+            fi
+            shopt -s nullglob
+            matches=(e2e-input/**/*.iso e2e-input/*.iso)
+            if [[ ${#matches[@]} -eq 0 ]]; then
+              echo "No ISO artifact found in workflow run: $source_run_id" >&2
+              exit 1
+            fi
+            iso_path="$(realpath "${matches[0]}")"
+          elif [[ -n "$iso_path" ]]; then
+            [[ -f "$iso_path" ]] || { echo "ISO path does not exist: $iso_path" >&2; exit 1; }
+            iso_path="$(realpath "$iso_path")"
+          else
+            shopt -s nullglob
+            matches=(./*.iso)
+            if [[ ${#matches[@]} -eq 0 ]]; then
+              echo "No ISO file found in the repository checkout" >&2
+              exit 1
+            fi
+            iso_path="$(realpath "${matches[0]}")"
+          fi
+          echo "iso_path=${iso_path}" >> "$GITHUB_OUTPUT"
+
+      - name: Run the e2e harness
+        env:
+          IMAGE_REF: ghcr.io/ublue-os/bluefin
+          IMAGE_TAG: stable
+        run: |
+          bash hack/iso-e2e-test.sh "${{ steps.context.outputs.iso_path }}" e2e-output
+
+      - name: Upload e2e proof
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: iso-e2e-proof-${{ github.run_id }}
+          if-no-files-found: error
+          path: e2e-output/

--- a/.github/workflows/iso-e2e-test.yml
+++ b/.github/workflows/iso-e2e-test.yml
@@ -133,7 +133,7 @@ jobs:
           IMAGE_REF: ghcr.io/ublue-os/bluefin
           IMAGE_TAG: stable
         run: |
-          bash hack/iso-e2e-test.sh "${{ steps.context.outputs.iso_path }}" e2e-output
+          bash tests/iso/e2e.sh "${{ steps.context.outputs.iso_path }}" e2e-output
 
       - name: Upload e2e proof
         if: always()

--- a/.github/workflows/iso-e2e-test.yml
+++ b/.github/workflows/iso-e2e-test.yml
@@ -89,7 +89,6 @@ jobs:
           DISPATCH_ISO_URL: ${{ github.event.client_payload.iso_url }}
           DISPATCH_SOURCE_RUN_ID: ${{ github.event.client_payload.source_run_id }}
           DISPATCH_ISO_PATH: ${{ github.event.client_payload.iso_path }}
-        env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/iso-smoke-test.yml
+++ b/.github/workflows/iso-smoke-test.yml
@@ -1,0 +1,213 @@
+name: ISO Smoke Test
+
+run-name: >-
+  ISO smoke validation for ${{ github.event.client_payload.release_tag || inputs.release_tag || 'manual' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      iso_url:
+        description: 'HTTPS URL for the ISO to test'
+        required: false
+        type: string
+      source_run_id:
+        description: 'Workflow run ID containing an ISO artifact'
+        required: false
+        type: string
+      artifact_name:
+        description: 'Optional ISO artifact name from source_run_id'
+        required: false
+        type: string
+      iso_path:
+        description: 'Path to a checked-in ISO in this repository'
+        required: false
+        type: string
+      release_tag:
+        description: 'Release tag used for this smoke run'
+        required: false
+        type: string
+      variant:
+        description: 'Variant being validated'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      iso_url:
+        description: 'HTTPS URL for the ISO to test'
+        required: false
+        type: string
+        default: ''
+      source_run_id:
+        description: 'Workflow run ID containing an ISO artifact'
+        required: false
+        type: string
+        default: ''
+      artifact_name:
+        description: 'Optional ISO artifact name from source_run_id'
+        required: false
+        type: string
+        default: ''
+      iso_path:
+        description: 'Path to an ISO available after checkout'
+        required: false
+        type: string
+        default: ''
+      release_tag:
+        description: 'Release tag used for this smoke run'
+        required: false
+        type: string
+        default: ''
+      variant:
+        description: 'Variant being validated'
+        required: false
+        type: string
+        default: ''
+  repository_dispatch:
+    types:
+      - iso-smoke-validation
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  smoke-test:
+    name: Boot ISO in QEMU
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Resolve smoke inputs
+        id: context
+        env:
+          INPUT_ISO_URL: ${{ inputs.iso_url }}
+          INPUT_SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          INPUT_ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          INPUT_ISO_PATH: ${{ inputs.iso_path }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_VARIANT: ${{ inputs.variant }}
+          DISPATCH_ISO_URL: ${{ github.event.client_payload.iso_url }}
+          DISPATCH_SOURCE_RUN_ID: ${{ github.event.client_payload.source_run_id }}
+          DISPATCH_ARTIFACT_NAME: ${{ github.event.client_payload.artifact_name }}
+          DISPATCH_ISO_PATH: ${{ github.event.client_payload.iso_path }}
+          DISPATCH_RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+          DISPATCH_VARIANT: ${{ github.event.client_payload.variant }}
+        run: |
+          set -euo pipefail
+          iso_url="${DISPATCH_ISO_URL:-${INPUT_ISO_URL}}"
+          source_run_id="${DISPATCH_SOURCE_RUN_ID:-${INPUT_SOURCE_RUN_ID}}"
+          artifact_name="${DISPATCH_ARTIFACT_NAME:-${INPUT_ARTIFACT_NAME}}"
+          iso_path="${DISPATCH_ISO_PATH:-${INPUT_ISO_PATH}}"
+          release_tag="${DISPATCH_RELEASE_TAG:-${INPUT_RELEASE_TAG}}"
+          variant="${DISPATCH_VARIANT:-${INPUT_VARIANT}}"
+          {
+            echo "iso_url=${iso_url}"
+            echo "source_run_id=${source_run_id}"
+            echo "artifact_name=${artifact_name}"
+            echo "iso_path=${iso_path}"
+            echo "release_tag=${release_tag}"
+            echo "variant=${variant}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate ISO source
+        env:
+          ISO_URL: ${{ steps.context.outputs.iso_url }}
+          SOURCE_RUN_ID: ${{ steps.context.outputs.source_run_id }}
+          ISO_PATH: ${{ steps.context.outputs.iso_path }}
+        run: |
+          set -euo pipefail
+          source_count=0
+          [[ -n "$ISO_URL" ]] && ((source_count += 1))
+          [[ -n "$SOURCE_RUN_ID" ]] && ((source_count += 1))
+          [[ -n "$ISO_PATH" ]] && ((source_count += 1))
+
+          if [[ "$source_count" -ne 1 ]]; then
+            echo "Provide exactly one of iso_url, source_run_id, or iso_path." >&2
+            exit 1
+          fi
+
+      - name: Download named source artifact
+        if: steps.context.outputs.source_run_id != '' && steps.context.outputs.artifact_name != ''
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.context.outputs.source_run_id }}
+          name: ${{ steps.context.outputs.artifact_name }}
+          path: downloaded-artifact
+
+      - name: Download source run artifacts
+        if: steps.context.outputs.source_run_id != '' && steps.context.outputs.artifact_name == ''
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.context.outputs.source_run_id }}
+          path: downloaded-artifact
+
+      - name: Resolve ISO list
+        id: iso
+        env:
+          ISO_URL: ${{ steps.context.outputs.iso_url }}
+          SOURCE_RUN_ID: ${{ steps.context.outputs.source_run_id }}
+          ISO_PATH: ${{ steps.context.outputs.iso_path }}
+        run: |
+          set -euo pipefail
+          iso_paths=()
+          if [[ -n "$ISO_URL" ]]; then
+            mkdir -p smoke-input
+            curl --fail --location --retry 3 --retry-all-errors \
+              --output smoke-input/source.iso "$ISO_URL"
+            iso_paths+=("$PWD/smoke-input/source.iso")
+          elif [[ -n "$ISO_PATH" ]]; then
+            [[ -f "$ISO_PATH" ]] || { echo "ISO path does not exist: $ISO_PATH" >&2; exit 1; }
+            iso_paths+=("$(realpath "$ISO_PATH")")
+          else
+            mapfile -d '' isos < <(find downloaded-artifact -type f -name '*.iso' -print0 | sort -z)
+            if [[ "${#isos[@]}" -eq 0 ]]; then
+              echo "No ISO files were found in the source artifacts." >&2
+              exit 1
+            fi
+            iso_paths=("${isos[@]}")
+          fi
+
+          iso_list="$RUNNER_TEMP/iso-list.txt"
+          printf '%s\n' "${iso_paths[@]}" > "$iso_list"
+          echo "path=$iso_list" >> "$GITHUB_OUTPUT"
+          echo "count=${#iso_paths[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Install QEMU and ISO inspection tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes qemu-system-x86 xorriso
+
+      - name: Run boot smoke test
+        id: smoke
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          iso_list="${{ steps.iso.outputs.path }}"
+          status=0
+          while IFS= read -r iso_path; do
+            [[ -n "$iso_path" ]] || continue
+            output_dir="smoke-output/$(basename "${iso_path%.*}")"
+            mkdir -p "$output_dir"
+            if ! tests/iso/smoke.sh "$iso_path" "$output_dir"; then
+              status=1
+            fi
+          done < "$iso_list"
+          exit "$status"
+
+      - name: Upload smoke proof
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: iso-smoke-proof-${{ github.run_id }}
+          if-no-files-found: error
+          path: smoke-output/
+
+      - name: Fail when the smoke test failed
+        if: steps.smoke.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/iso-testsuite.yml
+++ b/.github/workflows/iso-testsuite.yml
@@ -1,0 +1,36 @@
+name: ISO Validation via Testsuite
+
+on:
+  workflow_dispatch:
+    inputs:
+      iso_url:
+        description: "HTTPS URL for the ISO to validate"
+        required: true
+        type: string
+      iso_ref:
+        description: "Immutable ISO ref containing tests/iso"
+        required: true
+        type: string
+      variant:
+        description: "ISO variant"
+        required: false
+        default: ""
+        type: string
+      run_e2e:
+        description: "Run unattended installation and post-install boot validation"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate ISO through projectbluefin/testsuite
+    uses: projectbluefin/testsuite/.github/workflows/iso-validation.yml@3d4d65356f3dc8842ba84f142014e1d6fbf0237d
+    with:
+      iso_url: ${{ inputs.iso_url }}
+      iso_ref: ${{ inputs.iso_ref }}
+      variant: ${{ inputs.variant }}
+      run_e2e: ${{ inputs.run_e2e }}

--- a/.github/workflows/iso-testsuite.yml
+++ b/.github/workflows/iso-testsuite.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   validate:
     name: Validate ISO through projectbluefin/testsuite
-    uses: projectbluefin/testsuite/.github/workflows/iso-validation.yml@3d4d65356f3dc8842ba84f142014e1d6fbf0237d
+    uses: projectbluefin/testsuite/.github/workflows/iso-validation.yml@2c1d781353f68f060729f5af02917062f9a7f50b
     with:
       iso_url: ${{ inputs.iso_url }}
       iso_ref: ${{ inputs.iso_ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,5 +24,25 @@ jobs:
       image_version: stable
       image_tag: stable
       upload_r2: false
-      upload_artifacts: false
+      upload_artifacts: true
+    secrets: inherit
+
+  test-stable-main:
+    name: Stable main ISO E2E
+    needs: build-iso-stable
+    uses: ./.github/workflows/iso-e2e-test.yml
+    with:
+      source_run_id: ${{ github.run_id }}
+      artifact_name: iso-${{ github.run_id }}-stable-main-amd64
+      variant: stable
+    secrets: inherit
+
+  test-stable-nvidia:
+    name: Stable NVIDIA ISO E2E
+    needs: build-iso-stable
+    uses: ./.github/workflows/iso-e2e-test.yml
+    with:
+      source_run_id: ${{ github.run_id }}
+      artifact_name: iso-${{ github.run_id }}-stable-nvidia-open-amd64
+      variant: stable
     secrets: inherit

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -167,13 +167,29 @@ jobs:
 
       - name: Build ISO
         id: build
-        uses: ublue-os/titanoboa@main
-        with:
-          image-ref: ${{ steps.image_ref.outputs.image_ref }}:${{ inputs.image_tag || matrix.image_version }}
-          flatpaks-list: ${{ steps.flatpak_list.outputs.file_list_path }}
-          hook-post-rootfs: ${{ (matrix.image_version == 'lts' || matrix.image_version == 'lts-hwe') && format('{0}/iso_files/configure_lts_iso_anaconda.sh', github.workspace) || format('{0}/iso_files/configure_iso_anaconda.sh', github.workspace) }}
-          kargs: ${{ steps.image_ref.outputs.kargs }}
-          builder-distro: ${{ (matrix.image_version == 'lts' || matrix.image_version == 'lts-hwe') && 'centos' || 'fedora' }}
+        env:
+          IMAGE_REF: ${{ steps.image_ref.outputs.image_ref }}:${{ inputs.image_tag || matrix.image_version }}
+          FLATPAKS_LIST: ${{ steps.flatpak_list.outputs.file_list_path }}
+          HOOK_POST_ROOTFS: ${{ (matrix.image_version == 'lts' || matrix.image_version == 'lts-hwe') && format('{0}/iso_files/configure_lts_iso_anaconda.sh', github.workspace) || format('{0}/iso_files/configure_iso_anaconda.sh', github.workspace) }}
+          BUILDER_DISTRO: ${{ (matrix.image_version == 'lts' || matrix.image_version == 'lts-hwe') && 'centos' || 'fedora' }}
+        run: |
+          set -euo pipefail
+          titanoboa_dir="${RUNNER_TEMP}/titanoboa"
+          git clone --quiet https://github.com/ublue-os/titanoboa "${titanoboa_dir}"
+          git -C "${titanoboa_dir}" checkout --quiet 840217d97bd0bc9a52466508c54d8dda5c5ba2fd
+
+          # just 1.57 requires the list language feature used by which().
+          sed -i '1a set lists' "${titanoboa_dir}/Justfile"
+          just_bin="$(command -v just)"
+          sudo \
+            env PATH="${PATH}" \
+            CI="${CI}" \
+            HOOK_post_rootfs="${HOOK_POST_ROOTFS}" \
+            TITANOBOA_BUILDER_DISTRO="${BUILDER_DISTRO}" \
+            "${just_bin}" -f "${titanoboa_dir}/Justfile" build \
+            "${IMAGE_REF}" 1 "${FLATPAKS_LIST}" squashfs NONE '' 1
+          sudo chown "$(id -u):$(id -g)" "${titanoboa_dir}/output.iso"
+          mv "${titanoboa_dir}/output.iso" output.iso
 
       - name: Rename ISO
         id: rename

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -102,7 +102,7 @@ jobs:
 
           # Compact the JSON and output it
           compact_matrix=$(echo "$matrix" | jq -c .)
-          echo "matrix=$compact_matrix" >> $GITHUB_OUTPUT
+          echo "matrix=$compact_matrix" >> "${GITHUB_OUTPUT}"
           echo "Generated matrix:"
           echo "$matrix" | jq .
 
@@ -128,12 +128,12 @@ jobs:
             podman
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
 
       - name: Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Check Just Syntax
         shell: bash
@@ -152,9 +152,11 @@ jobs:
           effective_tag="${{ inputs.image_tag || matrix.image_version }}"
           artifact_format="$image_name-${effective_tag}-$(uname -m)"
           KARGS="NONE"
-          echo "image_ref=$image_ref" >> "${GITHUB_OUTPUT}"
-          echo "artifact_format=$artifact_format" >> "${GITHUB_OUTPUT}"
-          echo "kargs=$KARGS" >> "${GITHUB_OUTPUT}"
+          {
+            echo "image_ref=$image_ref"
+            echo "artifact_format=$artifact_format"
+            echo "kargs=$KARGS"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Generate titanoboa-compatible file list
         id: flatpak_list
@@ -187,7 +189,7 @@ jobs:
             HOOK_post_rootfs="${HOOK_POST_ROOTFS}" \
             TITANOBOA_BUILDER_DISTRO="${BUILDER_DISTRO}" \
             "${just_bin}" -f "${titanoboa_dir}/Justfile" build \
-            "${IMAGE_REF}" 1 "${FLATPAKS_LIST}" squashfs NONE '' 1
+            "${IMAGE_REF}" 1 "${FLATPAKS_LIST}" squashfs NONE "${IMAGE_REF}" 1
           sudo chown "$(id -u):$(id -g)" "${titanoboa_dir}/output.iso"
           mv "${titanoboa_dir}/output.iso" output.iso
 
@@ -198,12 +200,32 @@ jobs:
           FLAVOR: ${{ matrix.flavor }}
           OUTPUT_NAME: ${{ steps.image_ref.outputs.artifact_format }}
           IMAGE_VERSION: ${{ matrix.image_version }}
+          IMAGE_REF: ${{ steps.image_ref.outputs.image_ref }}
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
           set -x
           mkdir -p output
           OUTPUT_DIRECTORY="$(realpath output)"
           mv "${OUTPUT_PATH}" "${OUTPUT_DIRECTORY}/${OUTPUT_NAME}.iso"
           (cd "${OUTPUT_DIRECTORY}" && sha256sum "${OUTPUT_NAME}.iso" | tee "${OUTPUT_NAME}.iso-CHECKSUM")
+          iso_sha256="$(awk '{print $1}' "${OUTPUT_DIRECTORY}/${OUTPUT_NAME}.iso-CHECKSUM")"
+          cat > "${OUTPUT_DIRECTORY}/${OUTPUT_NAME}.manifest.json" <<EOF
+          {
+            "candidate_id": "${GITHUB_RUN_ID}-${OUTPUT_NAME}",
+            "source_repo": "${GITHUB_REPOSITORY}",
+            "source_sha": "${GITHUB_SHA}",
+            "source_run_id": "${GITHUB_RUN_ID}",
+            "variant": "${IMAGE_VERSION}",
+            "flavor": "${FLAVOR}",
+            "platform": "${PLATFORM:-$(uname -m)}",
+            "image_ref": "${IMAGE_REF:-${IMAGE_REGISTRY}/${IMAGE_NAME}}",
+            "image_tag": "${{ inputs.image_tag || matrix.image_version }}",
+            "iso_filename": "${OUTPUT_NAME}.iso",
+            "iso_sha256": "${iso_sha256}"
+          }
+          EOF
           echo "output_directory=$OUTPUT_DIRECTORY" >> "${GITHUB_OUTPUT}"
 
       - name: Generate Torrent File
@@ -240,6 +262,15 @@ jobs:
             "${OUTPUT_NAME}.iso"
 
           sha256sum "${OUTPUT_NAME}.iso.torrent" | tee "${OUTPUT_NAME}.iso.torrent-CHECKSUM"
+
+      - name: Upload ISO Artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: iso-${{ github.run_id }}-${{ matrix.image_version }}-${{ matrix.flavor }}-${{ matrix.platform }}
+          if-no-files-found: error
+          path: |
+            ${{ steps.rename.outputs.output_directory }}/${{ steps.image_ref.outputs.artifact_format }}.iso
+            ${{ steps.rename.outputs.output_directory }}/${{ steps.image_ref.outputs.artifact_format }}.manifest.json
 
       - name: Upload Run Torrent Artifacts
         if: inputs.upload_r2 && github.event_name != 'pull_request'
@@ -293,6 +324,8 @@ jobs:
   create-prerelease:
     name: Create GitHub Prerelease
     needs: build
+    outputs:
+      release_tag: ${{ steps.version.outputs.version }}
     # Run when builds complete (success or partial failure) — skip only on cancellation.
     # This ensures a prerelease is published even when arm64 builds fail, so
     # the amd64 ISOs that succeeded are still available on the releases page.
@@ -306,7 +339,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download Current Run Torrent Artifacts
         env:
@@ -366,7 +399,7 @@ jobs:
             VERSION="${YEAR_MONTH}"
           fi
 
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Build Platform Status
         id: build_status
@@ -436,6 +469,7 @@ jobs:
           fi
 
           NOTES_FILE="${RUNNER_TEMP}/prerelease-notes.md"
+          fence='```'
           {
             printf '%s\n' '## ⚠️ Prerelease - Testing Builds'
             printf '\n'
@@ -449,7 +483,7 @@ jobs:
             cat "${BUILD_STATUS_FILE}"
             printf '%s\n' '### How to Download'
             printf '\n'
-            printf '%s\n' '1. Download a `.torrent` file below'
+            printf '%s\n' "1. Download a \`.torrent\` file below"
             printf '%s\n' '2. Open with a BitTorrent client (qBittorrent, Transmission, etc.)'
             printf '%s\n' '3. Torrents include web seeds -- downloads work immediately'
             printf '\n'
@@ -459,17 +493,17 @@ jobs:
             printf '\n'
             printf '%s\n' '### Verify'
             printf '\n'
-            printf '%s\n' 'Verify your ISO download using the `.iso-CHECKSUM` files attached to this release:'
+            printf '%s\n' "Verify your ISO download using the \`.iso-CHECKSUM\` files attached to this release:"
             printf '\n'
-            printf '%s\n' '```bash'
+            printf '%s\n' "${fence}bash"
             printf '%s\n' 'sha256sum -c <filename>.iso-CHECKSUM'
-            printf '%s\n' '```'
+            printf '%s\n' "${fence}"
             printf '\n'
-            printf '%s\n' 'Verify a downloaded torrent file using the `.torrent-CHECKSUM` files:'
+            printf '%s\n' "Verify a downloaded torrent file using the \`.torrent-CHECKSUM\` files:"
             printf '\n'
-            printf '%s\n' '```bash'
+            printf '%s\n' "${fence}bash"
             printf '%s\n' 'sha256sum -c <filename>.iso.torrent-CHECKSUM'
-            printf '%s\n' '```'
+            printf '%s\n' "${fence}"
           } > "${NOTES_FILE}"
 
           gh release create "${VERSION}" \
@@ -478,3 +512,26 @@ jobs:
             --notes-file "${NOTES_FILE}" \
             "${TORRENT_FILES[@]}" \
             "${CHECKSUM_FILES[@]}"
+
+  trigger-smoke-validation:
+    name: Trigger ISO Smoke Validation
+    needs: create-prerelease
+    if: needs.create-prerelease.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Dispatch repo-local smoke validation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.create-prerelease.outputs.release_tag }}
+          VARIANT: ${{ inputs.image_version }}
+          SOURCE_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/dispatches" \
+            --raw-field event_type=iso-smoke-validation \
+            -f "client_payload[release_tag]=${RELEASE_TAG}" \
+            -f "client_payload[variant]=${VARIANT}" \
+            -f "client_payload[source_run_id]=${SOURCE_RUN_ID}"

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -26,6 +26,8 @@ name: Reusable Build
         required: false
       R2_ENDPOINT_2025:
         required: false
+      LAB_DISPATCH_TOKEN:
+        required: false
   pull_request:
     paths:
       - ".github/workflows/reusable-build-iso-anaconda.yml"
@@ -512,6 +514,45 @@ jobs:
             --notes-file "${NOTES_FILE}" \
             "${TORRENT_FILES[@]}" \
             "${CHECKSUM_FILES[@]}"
+
+      - name: Dispatch exact candidates to lab
+        if: env.LAB_DISPATCH_TOKEN != ''
+        env:
+          LAB_DISPATCH_TOKEN: ${{ secrets.LAB_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.LAB_DISPATCH_TOKEN }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID_2025 }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY_2025 }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT_2025 }}
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_RUN_ID: ${{ github.run_id }}
+          IMAGE_TAG: ${{ inputs.image_tag || inputs.image_version }}
+        run: |
+          set -euo pipefail
+          command -v aws >/dev/null || {
+            sudo apt-get update -y
+            sudo apt-get install -y awscli
+          }
+          shopt -s globstar nullglob
+          checksum_files=(checksums/**/*.iso-CHECKSUM)
+          for checksum_file in "${checksum_files[@]}"; do
+            iso_filename="$(basename "${checksum_file}" -CHECKSUM)"
+            iso_sha256="$(awk '{print $1}' "${checksum_file}")"
+            iso_url="$(AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+              AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+              aws s3 presign "s3://testing/${iso_filename}" \
+                --endpoint-url "${R2_ENDPOINT}" --region auto --expires-in 21600)"
+            jq -n \
+              --arg iso_url "${iso_url}" \
+              --arg iso_sha256 "${iso_sha256}" \
+              --arg source_repo "${SOURCE_REPO}" \
+              --arg source_sha "${SOURCE_SHA}" \
+              --arg candidate_id "${SOURCE_RUN_ID}-${iso_filename}" \
+              --arg image_tag "${IMAGE_TAG}" \
+              '{event_type:"iso-e2e-validation",client_payload:{iso_url:$iso_url,iso_sha256:$iso_sha256,source_repo:$source_repo,source_sha:$source_sha,candidate_id:$candidate_id,image_ref:"ghcr.io/ublue-os/bluefin",image_tag:$image_tag}}' \
+              | gh api --method POST repos/projectbluefin/lab/dispatches --input -
+            echo "Dispatched ${iso_filename} to projectbluefin/lab"
+          done
 
   trigger-smoke-validation:
     name: Trigger ISO Smoke Validation

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ Thumbs.db
 *.swo
 *~
 
+# Test artifacts
+.e2e-output/
+smoke-output/
+iso-test-output/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # OpenCode
 .opencode/
+.worktrees/
 
 # Build artifacts
 *_build*/

--- a/Justfile
+++ b/Justfile
@@ -596,6 +596,11 @@ build-iso $image="bluefin" $tag="latest" $flavor="main" ghcr="0" pipeline="0":
 build-iso-ghcr image="bluefin" tag="latest" flavor="main":
     @{{ just }} build-iso {{ image }} {{ tag }} {{ flavor }} 1
 
+# Run the complete local ISO test suite (boot smoke + unattended install)
+[group('ISO')]
+test-iso iso_path output_directory="iso-test-output":
+    bash tests/iso/suite.sh "{{ iso_path }}" "{{ output_directory }}"
+
 # Run ISO
 [group('ISO')]
 run-iso $image="bluefin" $tag="latest" $flavor="main":

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,51 @@
+# Architecture
+
+This document owns the repository's workflow and artifact model. Other documents should link here instead of repeating the matrix or pipeline.
+
+## Components
+
+| Area | Source of truth | Responsibility |
+| --- | --- | --- |
+| Build callers | `.github/workflows/build-iso-*.yml` | Trigger a fixed variant and pass inputs. |
+| Shared build | `.github/workflows/reusable-build-iso-anaconda.yml` | Select the matrix, build ISOs, create assets, and create a prerelease. |
+| Installer hooks | `iso_files/` | Configure the live environment and installer for the image base. |
+| Local recipes | `Justfile`, `just/`, `tests/iso/` | Build and test locally. `hack/` contains compatibility entry points only. |
+| Smoke validation | `.github/workflows/iso-smoke-test.yml` | Boot the exact candidate asset set in QEMU. |
+| Installer E2E | `.github/workflows/iso-e2e-test.yml`, `tests/iso/` | Exercise unattended installation and collect proof artifacts. |
+| Promotion | `.github/workflows/promote-iso.yml` | Gate, preview, and copy approved assets to production. |
+| External validation | `projectbluefin/testsuite/.github/workflows/iso-validation.yml` | Optional validation of published ISO URLs using an immutable ISO harness ref. |
+
+## Build matrix
+
+| Image version | ISO count | Platforms | Flavors |
+| --- | ---: | --- | --- |
+| `stable` | 2 | `amd64` | `main`, `nvidia-open` |
+| `lts` | 4 | `amd64`, `arm64` | `main`, `gdx` |
+| `lts-hwe` | 2 | `amd64`, `arm64` | `main` |
+
+The `lts-hwe-testing` image tag is owned only by `.github/workflows/build-iso-lts-hwe-testing.yml`. Do not add that tag to production callers.
+
+Non-HWE LTS is manual-only until its installer issue is resolved. Do not treat a successful build alone as production approval.
+
+## Artifact flow
+
+```text
+caller
+  -> reusable build
+  -> testing storage and prerelease
+  -> exact-candidate smoke validation
+  -> manual promotion preview
+  -> production storage and release
+```
+
+The smoke run must use the same prerelease tag and variant selected for promotion. Promotion excludes filenames containing `-testing-`.
+
+## Source boundaries
+
+System Flatpaks are sourced during the build. They are not maintained as a second local list in this repository.
+
+Stable and LTS-family variants use different installer hooks. Read the matching hook before changing installer behavior. Do not create a new hook when an existing hook owns the requested value.
+
+## Change rule
+
+When a workflow, matrix entry, source, artifact, or gate changes, update this document and the matching procedure in `docs/skills/`. Keep executable behavior in the workflow or script; keep explanation here.

--- a/docs/qa.md
+++ b/docs/qa.md
@@ -1,0 +1,66 @@
+# QA and validation
+
+This document owns validation commands, test levels, and release evidence. Do not treat generated test output as source.
+
+## Static checks
+
+Run the checks relevant to the change:
+
+```bash
+pre-commit run --all-files
+actionlint .github/workflows/*.yml
+just check
+```
+
+For changed shell scripts:
+
+```bash
+bash -n path/to/script.sh
+```
+
+Run `pre-commit` and `actionlint` before handoff. `just check` validates Just syntax.
+
+## Local ISO validation
+
+Use the existing recipes:
+
+```bash
+just local-iso-bluefin
+just local-iso-lts
+```
+
+Run the complete local suite against an ISO with both QEMU boot smoke and unattended installation checks:
+
+```bash
+just test-iso PATH_TO_ISO [OUTPUT_DIRECTORY]
+```
+
+The default output directory is `iso-test-output/`; it contains separate `smoke/` and `e2e/` proof artifacts. The command runs both checks and fails if either check fails.
+
+ISO creation requires root for the Titanoboa loop-device step. After changing an installer hook, rebuild the ISO and boot the new artifact. Do not patch a running VM and use that state as evidence.
+
+## Smoke validation
+
+`.github/workflows/iso-smoke-test.yml` validates the exact prerelease asset set that promotion will use. A passing result is required before promotion, including a dry-run preview.
+
+Review the workflow summary and downloaded proof artifacts. Record the prerelease tag, variant, workflow URL, result summary, serial log, and screen or proof artifacts when triaging a failure.
+
+## Installer E2E validation
+
+`.github/workflows/iso-e2e-test.yml` invokes the canonical `tests/iso/e2e.sh` harness (with `hack/iso-e2e-test.sh` retained as a compatibility entry point) to exercise unattended installation under QEMU. Use this path when the change affects installation, disk setup, boot, or post-install behavior.
+
+The harness writes logs, screenshots, summary data, and proof files to its output directory. It passes only after the installer reports completion and the installed system produces serial boot evidence. `E2E_INSTALL_TIMEOUT` (default 1800 seconds) and `E2E_POST_INSTALL_TIMEOUT` (default 180 seconds) can tune the two phases. Keep generated files out of source changes.
+
+## Failure rules
+
+- A failed smoke run blocks promotion.
+- A smoke run for another tag or variant is not evidence for the current candidate.
+- A missing or incomplete result is not a pass.
+- Do not replace failed evidence with a manually edited summary.
+- Fix the owning workflow, hook, or script, then rerun the relevant test.
+
+For published ISO URLs, `.github/workflows/iso-testsuite.yml` invokes the dedicated `projectbluefin/testsuite` ISO workflow. Pass the exact ISO URL and an immutable `iso_ref`; testsuite runs smoke plus unattended E2E by default and uploads the same proof artifacts. This is additive external validation and does not replace the repository-local promotion gate.
+
+## Documentation rule
+
+When a command, artifact, test gate, or required evidence changes, update this document and `docs/skills/test-iso/SKILL.md` in the same change.

--- a/docs/skills/build-iso/SKILL.md
+++ b/docs/skills/build-iso/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: build-iso
+description: Guides agents through changing and validating ISO build inputs. Use when modifying build matrices, image references, installer hooks, workflow callers, or local ISO recipes.
+---
+
+# Build ISO
+
+## Use when
+
+Use this skill for build matrices, image tags, caller inputs, shared build steps, installer hooks, Flatpak sourcing, and local ISO recipes.
+
+## Do not use when
+
+Do not use this skill for smoke evidence, installer E2E triage, or production promotion. Use `test-iso` or `release-iso` instead.
+
+## Inputs
+
+Read `docs/architecture.md` first. Then read the owning workflow, hook, script, or recipe before editing it.
+
+- Caller behavior: `.github/workflows/build-iso-*.yml`
+- Shared build: `.github/workflows/reusable-build-iso-anaconda.yml`
+- Installer hooks: `iso_files/`
+- Local commands: `Justfile`, `just/`, and `hack/`
+
+## Procedure
+
+1. Identify the single file that owns the requested behavior.
+2. Confirm the requested variant and image tag in the caller and reusable workflow.
+3. Preserve existing inputs, outputs, artifact names, and file formats.
+4. Keep the shared workflow on Titanoboa commit `840217d97bd0bc9a52466508c54d8dda5c5ba2fd` until its hook and Flatpak inputs are supported again; its Justfile needs `set lists` with current Just.
+5. Change the smallest existing structure that implements the request.
+5. Update `docs/architecture.md` when the matrix, source, artifact flow, or workflow boundary changes.
+6. Update this skill when the agent procedure changes.
+7. Do not edit generated ISO, build, smoke, or E2E output.
+
+## Verification
+
+```bash
+bash -n path/to/changed-script.sh
+just check
+pre-commit run --all-files
+actionlint .github/workflows/*.yml
+```
+
+For installer changes, rebuild and boot the ISO. Follow `docs/qa.md` for the applicable evidence.
+
+The current Titanoboa `main` action accepts only `image-ref` and `iso-dest`; using it here silently drops the installer hook and Flatpak inputs. The reusable workflow checks out the last compatible Titanoboa revision, adds `set lists` for current Just, and invokes its build recipe directly.
+
+## Related documents
+
+- [Architecture](../../architecture.md)
+- [QA](../../qa.md)
+- [Contributor workflow](../../contributing.md)

--- a/docs/skills/test-iso/SKILL.md
+++ b/docs/skills/test-iso/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: test-iso
+description: Guides agents through ISO validation and evidence collection. Use when running smoke tests, installer E2E tests, local ISO boots, or investigating validation artifacts.
+---
+
+# Test ISO
+
+## Use when
+
+Use this skill for static checks, shell checks, local ISO boots, QEMU smoke validation, unattended installer tests, logs, screenshots, and proof artifacts.
+
+## Do not use when
+
+Do not use this skill to change production filters or promote a release. Use `release-iso` for those tasks.
+
+## Procedure
+
+1. Read `docs/qa.md`.
+2. Run the smallest relevant static check.
+3. Reproduce the behavior with a fresh ISO when installer behavior changes.
+4. Use `.github/workflows/iso-smoke-test.yml` for candidate boot validation.
+5. Use `.github/workflows/iso-e2e-test.yml` or the canonical `tests/iso/e2e.sh` harness for unattended installation changes. The `hack/` path is compatibility-only.
+6. Preserve the exact candidate tag and variant in the test record.
+7. Keep generated output outside the source patch.
+8. Report failed or incomplete evidence as failed; never edit evidence to change its result.
+
+## Verification
+
+```bash
+pre-commit run --all-files
+actionlint .github/workflows/*.yml
+just check
+bash -n path/to/changed-script.sh
+```
+
+For the complete local suite (boot smoke plus unattended installation):
+
+```bash
+just test-iso PATH_TO_ISO iso-test-output
+```
+
+Or run only the installer E2E check:
+
+```bash
+E2E_POST_INSTALL_TIMEOUT=300 bash tests/iso/e2e.sh PATH_TO_ISO e2e-output
+```
+
+The installer E2E phase passes only after the installer reports completion and the installed system produces serial-console boot evidence.
+
+A promotion candidate requires a successful matching smoke run. A run for another tag or variant is not evidence.
+
+## Related documents
+
+- [QA](../../qa.md)
+- [Architecture](../../architecture.md)
+- [Release procedure](../../release.md)

--- a/hack/iso-e2e-test.sh
+++ b/hack/iso-e2e-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Compatibility entry point. Canonical implementation lives under tests/iso.
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec bash "$repo_root/tests/iso/e2e.sh" "$@"

--- a/hack/iso-smoke-test.sh
+++ b/hack/iso-smoke-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Compatibility entry point. Canonical implementation lives under tests/iso.
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec bash "$repo_root/tests/iso/smoke.sh" "$@"

--- a/hack/iso-test.sh
+++ b/hack/iso-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Compatibility entry point. Canonical implementation lives under tests/iso.
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec bash "$repo_root/tests/iso/suite.sh" "$@"

--- a/hack/local-iso-build.sh
+++ b/hack/local-iso-build.sh
@@ -39,7 +39,7 @@ if [ ! -f "$hook_script" ]; then
     exit 1
 fi
 
-BUILD_DIR="$REPO_ROOT/.build/${variant}-${flavor}"
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/.build/${variant}-${flavor}}"
 
 # Construct the image URI
 if [ "$flavor" != "base" ]; then
@@ -145,10 +145,10 @@ cd "$BUILD_DIR"
 # Run the Titanoboa build command
 # Titanoboa needs root podman for loop device access during ISO creation
 echo "Running Titanoboa build..."
-export PODMAN="sudo /usr/bin/podman"
+export PODMAN="${PODMAN:-sudo /usr/bin/podman}"
 TITANOBOA_BUILDER_DISTRO="$IMAGE_DISTRO" \
 	HOOK_post_rootfs="hook.sh" \
-    just PODMAN="sudo /usr/bin/podman" build "$TARGET_IMAGE_NAME" 1 flatpaks.list || true
+    just PODMAN="$PODMAN" build "$TARGET_IMAGE_NAME" 1 flatpaks.list || true
 
 echo "Titanoboa build process finished."
 

--- a/hack/local-iso-build.sh
+++ b/hack/local-iso-build.sh
@@ -120,9 +120,9 @@ fi
 
 
 
-# Patch Titanoboa Justfile to ignore setfiles errors (workaround for smartmontools/FS issues)
-echo "Patching Titanoboa Justfile to ignore setfiles errors..."
-sed -i 's/setfiles -F -r . \/etc\/selinux\/targeted\/contexts\/files\/file_contexts ./setfiles -F -r . \/etc\/selinux\/targeted\/contexts\/files\/file_contexts . || true/' "$BUILD_DIR/Justfile"
+# Patch Titanoboa Justfile to ignore SELinux xattr errors on container-backed filesystems.
+echo "Patching Titanoboa Justfile to ignore SELinux xattr errors..."
+sed -i -E '/^[[:space:]]+setfiles / s/$/ || true/; /^[[:space:]]+chcon / s/$/ || true/' "$BUILD_DIR/Justfile"
 
 # Patch Titanoboa Justfile to ensure builder has device access (fix loop mount)
 echo "Patching Titanoboa Justfile to add --device /dev/fuse to builder..."

--- a/hack/local-iso-build.sh
+++ b/hack/local-iso-build.sh
@@ -120,6 +120,11 @@ fi
 
 
 
+# Titanoboa uses which(), which requires Just's current `set lists` mode.
+if ! grep -qx 'set lists' "$BUILD_DIR/Justfile"; then
+    sed -i '1i set lists' "$BUILD_DIR/Justfile"
+fi
+
 # Patch Titanoboa Justfile to ignore SELinux xattr errors on container-backed filesystems.
 echo "Patching Titanoboa Justfile to ignore SELinux xattr errors..."
 sed -i -E '/^[[:space:]]+setfiles / s/$/ || true/; /^[[:space:]]+chcon / s/$/ || true/' "$BUILD_DIR/Justfile"

--- a/tests/iso/data/bluefin-unattended.ks.tmpl
+++ b/tests/iso/data/bluefin-unattended.ks.tmpl
@@ -1,0 +1,12 @@
+lang en_US.UTF-8
+keyboard us
+timezone UTC --utc
+network --bootproto=dhcp --device=link --activate
+zerombr
+clearpart --all --initlabel
+autopart --type=plain
+rootpw --plaintext bluefin
+user --name=bluefin --password bluefin --groups=wheel
+bootloader --location=mbr --append="console=ttyS0"
+ostreecontainer --url=__IMAGE_REF__:__IMAGE_TAG__ --transport=containers-storage --no-signature-verification
+reboot

--- a/tests/iso/e2e.sh
+++ b/tests/iso/e2e.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 ISO_PATH [OUTPUT_DIRECTORY]" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    usage
+    exit 2
+fi
+
+iso_path="$1"
+output_directory="${2:-e2e-output}"
+mkdir -p "$output_directory"
+output_directory="$(cd "$output_directory" && pwd)"
+
+qemu_binary="${QEMU_BINARY:-qemu-system-x86_64}"
+qemu_img_binary="${QEMU_IMG_BINARY:-qemu-img}"
+qemu_machine="${QEMU_MACHINE:-q35}"
+qemu_accel="${QEMU_ACCEL:-kvm:tcg}"
+http_port="${E2E_HTTP_PORT:-18080}"
+image_ref="${IMAGE_REF:-ghcr.io/ublue-os/bluefin}"
+image_tag="${IMAGE_TAG:-stable}"
+disk_size="${E2E_DISK_SIZE:-32G}"
+install_timeout="${E2E_INSTALL_TIMEOUT:-1800}"
+post_install_timeout="${E2E_POST_INSTALL_TIMEOUT:-180}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+template_file="$script_dir/data/bluefin-unattended.ks.tmpl"
+serial_file="$output_directory/installer-serial.log"
+post_install_serial="$output_directory/post-install-serial.log"
+summary_file="$output_directory/e2e-summary.json"
+proof_file="$output_directory/e2e-proof.svg"
+final_screen_ppm="$output_directory/final-screen.ppm"
+final_screen_png="$output_directory/final-screen.png"
+install_disk="$output_directory/installed.qcow2"
+http_root="$output_directory/http-root"
+work_dir="$output_directory/.work"
+kernel_path="$work_dir/vmlinuz"
+initrd_path="$work_dir/initramfs.img"
+qmp_socket="$output_directory/.work/qmp.sock"
+post_qmp_socket="$output_directory/.work/post-qmp.sock"
+
+mkdir -p "$http_root" "$work_dir"
+
+install_pid=""
+post_install_pid=""
+
+if [[ ! -f "$iso_path" ]]; then
+    echo "ISO does not exist: $iso_path" >&2
+    exit 1
+fi
+
+if ! command -v "$qemu_img_binary" >/dev/null 2>&1; then
+    echo "QEMU image tool not found: $qemu_img_binary" >&2
+    exit 1
+fi
+
+if ! command -v "$qemu_binary" >/dev/null 2>&1; then
+    echo "QEMU binary not found: $qemu_binary" >&2
+    exit 1
+fi
+
+kickstart_file="$http_root/kickstart.ks"
+python3 - "$work_dir/bluefin-unattended.ks" "$template_file" "$image_ref" "$image_tag" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[2])
+text = source.read_text()
+text = text.replace('__IMAGE_REF__', sys.argv[3])
+text = text.replace('__IMAGE_TAG__', sys.argv[4])
+pathlib.Path(sys.argv[1]).write_text(text)
+PY
+cp "$work_dir/bluefin-unattended.ks" "$kickstart_file"
+
+if [[ ! -f "$kernel_path" ]]; then
+    xorriso -indev "$iso_path" -osirrox on -extract /boot/vmlinuz "$kernel_path"
+fi
+
+if [[ ! -f "$initrd_path" ]]; then
+    xorriso -indev "$iso_path" -osirrox on -extract /boot/initramfs.img "$initrd_path"
+fi
+
+if [[ ! -f "$install_disk" ]]; then
+    "$qemu_img_binary" create -f qcow2 "$install_disk" "$disk_size"
+fi
+
+python3 -m http.server "$http_port" --bind 0.0.0.0 --directory "$http_root" >/dev/null 2>&1 &
+http_server_pid=$!
+cleanup() {
+    local exit_code=$?
+    for pid in "$install_pid" "$post_install_pid"; do
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+    kill "$http_server_pid" 2>/dev/null || true
+    wait "$http_server_pid" 2>/dev/null || true
+    rm -rf "$work_dir"
+    exit "$exit_code"
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 20); do
+    if curl --silent --show-error --fail "http://127.0.0.1:${http_port}/kickstart.ks" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+"$qemu_binary" \
+    -name bluefin-e2e \
+    -machine "${qemu_machine},accel=${qemu_accel}" \
+    -cpu max \
+    -m 4096 \
+    -smp 2 \
+    -drive file="$install_disk",format=qcow2,if=virtio,cache=none \
+    -cdrom "$iso_path" \
+    -kernel "$kernel_path" \
+    -initrd "$initrd_path" \
+    -netdev user,id=net0 \
+    -device virtio-net-pci,netdev=net0 \
+    -serial "file:$serial_file" \
+    -vga std \
+    -display none \
+    -monitor none \
+    -qmp "unix:$qmp_socket,server=on,wait=off" \
+    -append "console=ttyS0 rd.live.image rd.live.ram rd.neednet=1 ip=dhcp root=live:CDLABEL=titanoboa_boot inst.ks=http://10.0.2.2:${http_port}/kickstart.ks inst.text" \
+    -no-reboot > /dev/null 2>&1 &
+install_pid=$!
+
+install_evidence=""
+start_time=$SECONDS
+while (( SECONDS - start_time < install_timeout )); do
+    if grep -Eqi 'Installation complete|Rebooting|Powering off|reboot: Power down' "$serial_file" 2>/dev/null; then
+        install_evidence="installer-complete"
+        break
+    fi
+    if ! kill -0 "$install_pid" 2>/dev/null; then
+        wait "$install_pid" || true
+        break
+    fi
+    sleep 10
+done
+
+if [[ -z "$install_evidence" ]]; then
+    if kill -0 "$install_pid" 2>/dev/null; then
+        kill "$install_pid" 2>/dev/null || true
+        wait "$install_pid" 2>/dev/null || true
+    fi
+    echo "Installer did not report completion within ${install_timeout}s" >&2
+    exit 1
+fi
+
+kill "$install_pid" 2>/dev/null || true
+wait "$install_pid" 2>/dev/null || true
+install_pid=""
+
+"$qemu_binary" \
+    -name bluefin-e2e-postinstall \
+    -machine "${qemu_machine},accel=${qemu_accel}" \
+    -cpu max \
+    -m 4096 \
+    -smp 2 \
+    -drive file="$install_disk",format=qcow2,if=virtio,cache=none \
+    -netdev user,id=net0 \
+    -device virtio-net-pci,netdev=net0 \
+    -serial "file:$post_install_serial" \
+    -vga std \
+    -display none \
+    -monitor none \
+    -qmp "unix:$post_qmp_socket,server=on,wait=off" \
+    > /dev/null 2>&1 &
+post_install_pid=$!
+
+post_install_evidence=""
+post_start=$SECONDS
+while (( SECONDS - post_start < post_install_timeout )); do
+    if grep -Eqi 'Linux version|Reached target (multi-user|graphical)|bluefin login:|login:' "$post_install_serial" 2>/dev/null; then
+        post_install_evidence="installed-system-booted"
+        break
+    fi
+    if ! kill -0 "$post_install_pid" 2>/dev/null; then
+        wait "$post_install_pid" || true
+        break
+    fi
+    sleep 5
+done
+
+if [[ -z "$post_install_evidence" ]]; then
+    echo "Installed system did not boot within ${post_install_timeout}s" >&2
+    exit 1
+fi
+
+for _ in $(seq 1 10); do
+    [[ -S "$post_qmp_socket" ]] && break
+    sleep 1
+done
+if [[ ! -S "$post_qmp_socket" ]]; then
+    echo "Installed system booted on serial console but QEMU monitor was unavailable for capture" >&2
+    exit 1
+fi
+
+if command -v ffmpeg >/dev/null 2>&1; then
+    python3 - "$post_qmp_socket" "$final_screen_ppm" <<'PY'
+import json
+import socket
+import sys
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.settimeout(10)
+sock.connect(sys.argv[1])
+
+def read_message():
+    data = b''
+    while b'\r\n' not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise RuntimeError('QMP socket closed')
+        data += chunk
+    return json.loads(data.split(b'\r\n', 1)[0])
+
+read_message()
+sock.sendall(b'{"execute":"qmp_capabilities"}\r\n')
+read_message()
+command = {"execute": "screendump", "arguments": {"filename": sys.argv[2]}}
+sock.sendall((json.dumps(command) + "\r\n").encode())
+response = read_message()
+if 'error' in response:
+    raise RuntimeError(response['error']['desc'])
+PY
+    ffmpeg -y -loglevel error -i "$final_screen_ppm" "$final_screen_png" >/dev/null 2>&1 || true
+fi
+
+kill "$post_install_pid" 2>/dev/null || true
+wait "$post_install_pid" 2>/dev/null || true
+
+python3 - "$summary_file" "$iso_path" "$serial_file" "$post_install_serial" "$final_screen_png" "$install_evidence" "$post_install_evidence" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+summary_path = Path(sys.argv[1])
+iso_path = Path(sys.argv[2])
+serial_path = Path(sys.argv[3])
+post_install_serial = Path(sys.argv[4])
+image_path = Path(sys.argv[5])
+install_evidence = sys.argv[6]
+post_install_evidence = sys.argv[7]
+summary = {
+    'result': 'passed' if install_evidence and post_install_evidence else 'failed',
+    'iso': str(iso_path),
+    'install_evidence': install_evidence or None,
+    'post_install_evidence': post_install_evidence or None,
+    'serial_log': serial_path.name if serial_path.exists() else None,
+    'post_install_serial_log': post_install_serial.name if post_install_serial.exists() else None,
+    'final_screen_image': image_path.name if image_path.exists() else None,
+}
+summary_path.write_text(json.dumps(summary, indent=2) + '\n')
+PY
+
+cat > "$proof_file" <<EOF
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="320" role="img" aria-label="Bluefin ISO E2E proof">
+  <rect width="100%" height="100%" fill="#101820"/>
+  <text x="24" y="28" fill="#66ff99" font-family="monospace" font-size="20">Bluefin ISO E2E proof</text>
+  <text x="24" y="80" fill="#ffffff" font-family="monospace" font-size="16">Installer completed and installed system booted</text>
+</svg>
+EOF

--- a/tests/iso/smoke.sh
+++ b/tests/iso/smoke.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 ISO_PATH [OUTPUT_DIRECTORY]" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    usage
+    exit 2
+fi
+
+iso_path="$1"
+output_directory="${2:-smoke-output}"
+timeout_seconds="${QEMU_TIMEOUT_SECONDS:-90}"
+qemu_binary="${QEMU_BINARY:-qemu-system-x86_64}"
+qemu_machine="${QEMU_MACHINE:-q35}"
+qemu_accel="${QEMU_ACCEL:-kvm:tcg}"
+
+mkdir -p "$output_directory"
+output_directory="$(cd "$output_directory" && pwd)"
+proof_file="$output_directory/smoke-proof.svg"
+summary_file="$output_directory/smoke-summary.json"
+screen_file="$output_directory/smoke-screen.ppm"
+screen_png="$output_directory/smoke-screen.png"
+serial_file="$output_directory/serial.log"
+runtime_directory="$output_directory/.runtime"
+qmp_socket="$runtime_directory/qmp.sock"
+
+result_message=""
+qemu_status="not-started"
+boot_evidence="none"
+qemu_pid=""
+
+write_results() {
+    local exit_code="$1"
+    local result="failed"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        result="passed"
+    fi
+
+    ISO_PATH="$iso_path" \
+    RESULT="$result" \
+    RESULT_MESSAGE="$result_message" \
+    QEMU_STATUS="$qemu_status" \
+    BOOT_EVIDENCE="$boot_evidence" \
+    SCREEN_FILE="$screen_file" \
+    SCREEN_PNG="$screen_png" \
+    SERIAL_FILE="$serial_file" \
+    SUMMARY_FILE="$summary_file" \
+    PROOF_FILE="$proof_file" \
+    python3 - <<'PY'
+import hashlib
+import html
+import json
+import os
+from pathlib import Path
+
+iso = Path(os.environ["ISO_PATH"])
+screen = Path(os.environ["SCREEN_FILE"])
+serial = Path(os.environ["SERIAL_FILE"])
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+summary = {
+    "result": os.environ["RESULT"],
+    "message": os.environ["RESULT_MESSAGE"],
+    "iso": str(iso),
+    "iso_sha256": sha256(iso) if iso.is_file() else None,
+    "iso_size_bytes": iso.stat().st_size if iso.is_file() else None,
+    "qemu_status": os.environ["QEMU_STATUS"],
+    "boot_evidence": os.environ["BOOT_EVIDENCE"],
+    "screen_capture": screen.name if screen.is_file() else None,
+"screen_image": os.path.basename(os.environ["SCREEN_PNG"]) if os.path.exists(os.environ["SCREEN_PNG"]) else None,
+"serial_log": serial.name if serial.is_file() else None,
+}
+Path(os.environ["SUMMARY_FILE"]).write_text(json.dumps(summary, indent=2) + "\n")
+
+rows = "".join(
+    f"<text x='24' y='{48 + index * 28}'>{html.escape(f'{key}: {value}')}</text>"
+    for index, (key, value) in enumerate(summary.items())
+)
+proof = """<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="320" role="img"
+  aria-label="ISO smoke test proof">
+  <rect width="100%" height="100%" fill="#101820"/>
+  <text x="24" y="28" fill="#66ff99" font-family="monospace" font-size="20">Bluefin ISO smoke test</text>
+  <g fill="#ffffff" font-family="monospace" font-size="16">""" + rows + """</g>
+</svg>
+"""
+Path(os.environ["PROOF_FILE"]).write_text(proof)
+PY
+}
+
+convert_screen_to_png() {
+    if [[ -f "$screen_file" ]] && command -v ffmpeg >/dev/null 2>&1; then
+        ffmpeg -y -loglevel error -i "$screen_file" "$screen_png" >/dev/null 2>&1 || true
+    fi
+}
+
+cleanup() {
+    local exit_code=$?
+
+    if [[ -n "$qemu_pid" ]] && kill -0 "$qemu_pid" 2>/dev/null; then
+        kill "$qemu_pid" 2>/dev/null || true
+        wait "$qemu_pid" 2>/dev/null || true
+    fi
+
+    convert_screen_to_png
+    rm -rf "$runtime_directory"
+    write_results "$exit_code"
+}
+
+trap cleanup EXIT
+
+fail() {
+    result_message="$1"
+    echo "Error: $result_message" >&2
+    exit 1
+}
+
+qmp_status() {
+    python3 - "$qmp_socket" <<'PY'
+import json
+import socket
+import sys
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.settimeout(5)
+sock.connect(sys.argv[1])
+
+def read_message():
+    data = b""
+    while b"\r\n" not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise RuntimeError("QMP socket closed")
+        data += chunk
+    return json.loads(data.split(b"\r\n", 1)[0])
+
+read_message()
+sock.sendall(b'{"execute":"qmp_capabilities"}\r\n')
+read_message()
+sock.sendall(b'{"execute":"query-status"}\r\n')
+print(read_message()["return"]["status"])
+PY
+}
+
+capture_screen() {
+    python3 - "$qmp_socket" "$screen_file" <<'PY'
+import json
+import socket
+import sys
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.settimeout(10)
+sock.connect(sys.argv[1])
+
+def read_message():
+    data = b""
+    while b"\r\n" not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise RuntimeError("QMP socket closed")
+        data += chunk
+    return json.loads(data.split(b"\r\n", 1)[0])
+
+read_message()
+sock.sendall(b'{"execute":"qmp_capabilities"}\r\n')
+read_message()
+command = {"execute": "screendump", "arguments": {"filename": sys.argv[2]}}
+sock.sendall((json.dumps(command) + "\r\n").encode())
+response = read_message()
+if "error" in response:
+    raise RuntimeError(response["error"]["desc"])
+PY
+}
+
+[[ -f "$iso_path" ]] || fail "ISO does not exist: $iso_path"
+[[ "$timeout_seconds" =~ ^[1-9][0-9]*$ ]] || fail "QEMU_TIMEOUT_SECONDS must be a positive integer"
+command -v "$qemu_binary" >/dev/null || fail "qemu-system-x86_64 is not installed"
+command -v xorriso >/dev/null || fail "xorriso is not installed"
+
+if ! xorriso -indev "$iso_path" -report_el_torito plain 2>&1 | grep -q "El Torito"; then
+    fail "ISO has no readable El Torito boot catalog"
+fi
+
+mkdir -p "$runtime_directory"
+"$qemu_binary" \
+    -name iso-smoke-test \
+    -machine ${qemu_machine},accel=${qemu_accel} \
+    -cpu max \
+    -m 4096 \
+    -smp 2 \
+    -boot once=d \
+    -cdrom "$iso_path" \
+    -vga std \
+    -display none \
+    -serial "file:$serial_file" \
+    -monitor none \
+    -qmp "unix:$qmp_socket,server=on,wait=off" \
+    -no-reboot &
+qemu_pid=$!
+
+for _ in $(seq 1 15); do
+    [[ -S "$qmp_socket" ]] && break
+    if ! kill -0 "$qemu_pid" 2>/dev/null; then
+        wait "$qemu_pid" || true
+        fail "QEMU exited before its monitor became available"
+    fi
+    sleep 1
+done
+
+[[ -S "$qmp_socket" ]] || fail "QEMU monitor did not become available"
+
+deadline=$((SECONDS + timeout_seconds))
+started_at=$SECONDS
+while (( SECONDS < deadline )); do
+    if ! kill -0 "$qemu_pid" 2>/dev/null; then
+        wait "$qemu_pid" || true
+        fail "QEMU exited before the ISO completed its boot smoke window"
+    fi
+
+    qemu_status="$(qmp_status)" || fail "Unable to query QEMU monitor status"
+    [[ "$qemu_status" == "running" ]] || fail "QEMU is not running (status: $qemu_status)"
+
+    if grep -Eqi 'Linux version|dracut|anaconda|Starting ' "$serial_file" 2>/dev/null; then
+        boot_evidence="serial-console"
+        break
+    fi
+
+    sleep 5
+done
+
+if [[ "$boot_evidence" == "none" ]]; then
+    boot_evidence="qemu-running"
+fi
+
+capture_screen || fail "Unable to capture the QEMU display"
+[[ -s "$screen_file" ]] || fail "QEMU display capture is empty"
+result_message="QEMU ran for $((SECONDS - started_at)) seconds with ${boot_evidence} evidence"

--- a/tests/iso/suite.sh
+++ b/tests/iso/suite.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+usage() {
+    echo "Usage: $0 ISO_PATH [OUTPUT_DIRECTORY]" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    usage
+    exit 2
+fi
+
+iso_path="$1"
+output_directory="${2:-iso-test-output}"
+smoke_output="$output_directory/smoke"
+e2e_output="$output_directory/e2e"
+
+mkdir -p "$output_directory"
+status=0
+
+if ! bash "$(dirname "$0")/iso-smoke-test.sh" "$iso_path" "$smoke_output"; then
+    status=1
+fi
+
+if ! bash "$(dirname "$0")/iso-e2e-test.sh" "$iso_path" "$e2e_output"; then
+    status=1
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary
- preserve Titanoboa installer-hook and Flatpak inputs with a compatible build path
- make ISO artifacts available to downstream E2E jobs
- implement source workflow-run artifact download in the ISO E2E workflow
- run stable main and NVIDIA installer E2E jobs on pull requests

## Validation
- pre-commit run --all-files
- actionlint .github/workflows/*.yml
- just check
- python3 hack/check-docs.py

Stable build validation: https://github.com/projectbluefin/iso/actions/runs/29781623548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated ISO smoke and end-to-end testing, including downloadable validation evidence.
  * Added a unified ISO test command for local validation.
  * Added documentation checks and expanded build, QA, release, and contribution guidance.
  * Pull request ISO builds now run stable image installation tests.

* **Bug Fixes**
  * ISO promotion now requires a successful smoke-test validation before proceeding.
  * LTS ISO builds are manual-only until an upstream image issue is resolved.

* **Improvements**
  * Build outputs now include manifests and checksums for easier verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->