### PR TITLE
ci(iso): reclaim runner disk before builds

### DIFF
--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -121,6 +121,11 @@ jobs:
       id-token: write
 
     steps:
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
+        with:
+          extra-squeeze: "true"
+
       - name: Install dependencies
         if: matrix.platform == 'arm64'
         run: |

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-map
 version: "1.0"
-last_updated: 2026-07-17
+last_updated: 2026-08-04
 tags: [workflows, iso, build]
 description: "Use when you need to understand how the Bluefin ISO builder workflows fit together or update workflow documentation for this repository."
 metadata:
@@ -56,6 +56,7 @@ Do not use this skill for implementation changes that belong in the workflow fil
 
 ## Operational notes
 
+- The reusable build job runs the org-standard disk cleanup action before dependency installation and checkout. Keep it at the start of the job because Titanoboa expands the source image's OSTree layers onto the runner.
 - LTS non-HWE production promotion is disabled while the LTS build remains broken.
 - Only `variant: stable` promotion is safe until the LTS issue is resolved.
 - Flatpak lists are assembled at build time from `projectbluefin/common`'s `*system-flatpaks.Brewfile` files.


### PR DESCRIPTION
## Summary

- reclaim runner disk at the start of every shared Titanoboa ISO build
- use the current org-standard `remove-unwanted-software` v10 pin with `extra-squeeze`
- document why cleanup must remain ahead of dependency installation and checkout

## Context

projectbluefin/common#796 reports intermittent ENOSPC failures while non-composefs images expand their OSTree layers. Dakota already applies this mitigation, but this reusable workflow still builds Stable and LTS-HWE OSTree ISOs without it. This restores the targeted cleanup removed in projectbluefin/iso#31 without restoring the old loopback storage action.

The Common image build already gets equivalent cleanup from `projectbluefin/actions/bootc-build/setup-runner`, so applying the fix here avoids duplicating work in an unrelated workflow.

## Validation

- `uvx pre-commit run --all-files`
- `just check`

Fixes projectbluefin/common#796