### PR TITLE
fix(ci): restore ISO rename output and soft-fail arm64 legs

### DIFF
--- a/.github/workflows/iso-e2e-test.yml
+++ b/.github/workflows/iso-e2e-test.yml
@@ -30,6 +30,11 @@ on:
         description: 'Variant being validated'
         required: false
         type: string
+      luks:
+        description: 'Install with LUKS full-disk encryption and verify unlock at boot'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       iso_url:
@@ -62,6 +67,11 @@ on:
         required: false
         type: string
         default: ''
+      luks:
+        description: 'Install with LUKS full-disk encryption and verify unlock at boot'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -131,7 +141,12 @@ jobs:
       - name: Run the e2e harness
         env:
           IMAGE_REF: ghcr.io/ublue-os/bluefin
-          IMAGE_TAG: stable
+          # The kickstart's ostreecontainer ref must match the image embedded
+          # in the ISO's container storage, which follows the variant.
+          IMAGE_TAG: ${{ startsWith(inputs.variant, 'lts') && inputs.variant || 'stable' }}
+          E2E_LUKS: ${{ inputs.luks && '1' || '0' }}
+          # LUKS boots pause at the passphrase prompt before the login marker.
+          E2E_POST_INSTALL_TIMEOUT: ${{ inputs.luks && '600' || '180' }}
         run: |
           bash tests/iso/e2e.sh "${{ steps.context.outputs.iso_path }}" e2e-output
 

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -111,6 +111,11 @@ jobs:
   build:
     name: Build ISOs
     runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    # arm64 source images (ghcr.io/ublue-os/bluefin:lts / lts-hwe) are currently
+    # missing from the published manifest lists, so arm64 legs cannot pull a
+    # rootfs. Soft-fail them until the upstream manifests carry arm64 again,
+    # so amd64 ISOs keep publishing.
+    continue-on-error: ${{ matrix.platform == 'arm64' }}
     needs: determine-matrix
     strategy:
       fail-fast: false
@@ -194,6 +199,7 @@ jobs:
             "${IMAGE_REF}" 1 "${FLATPAKS_LIST}" squashfs NONE "${IMAGE_REF}" 1
           sudo chown "$(id -u):$(id -g)" "${titanoboa_dir}/output.iso"
           mv "${titanoboa_dir}/output.iso" output.iso
+          echo "iso-dest=$(realpath output.iso)" >> "${GITHUB_OUTPUT}"
 
       - name: Rename ISO
         id: rename

--- a/tests/iso/data/bluefin-unattended.ks.tmpl
+++ b/tests/iso/data/bluefin-unattended.ks.tmpl
@@ -4,7 +4,7 @@ timezone UTC --utc
 network --bootproto=dhcp --device=link --activate
 zerombr
 clearpart --all --initlabel
-autopart --type=plain
+autopart --type=plain __AUTOPART_EXTRA__
 rootpw --plaintext bluefin
 user --name=bluefin --password bluefin --groups=wheel
 bootloader --location=mbr --append="console=ttyS0"

--- a/tests/iso/e2e.sh
+++ b/tests/iso/e2e.sh
@@ -26,6 +26,8 @@ image_tag="${IMAGE_TAG:-stable}"
 disk_size="${E2E_DISK_SIZE:-32G}"
 install_timeout="${E2E_INSTALL_TIMEOUT:-1800}"
 post_install_timeout="${E2E_POST_INSTALL_TIMEOUT:-180}"
+luks_enabled="${E2E_LUKS:-0}"
+luks_passphrase="${E2E_LUKS_PASSPHRASE:-bluefin-e2e-luks}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 template_file="$script_dir/data/bluefin-unattended.ks.tmpl"
@@ -63,8 +65,13 @@ if ! command -v "$qemu_binary" >/dev/null 2>&1; then
     exit 1
 fi
 
+autopart_extra=""
+if [[ "$luks_enabled" == "1" ]]; then
+    autopart_extra="--encrypted --luks-version=luks2 --passphrase=${luks_passphrase}"
+fi
+
 kickstart_file="$http_root/kickstart.ks"
-python3 - "$work_dir/bluefin-unattended.ks" "$template_file" "$image_ref" "$image_tag" <<'PY'
+python3 - "$work_dir/bluefin-unattended.ks" "$template_file" "$image_ref" "$image_tag" "$autopart_extra" <<'PY'
 import pathlib
 import sys
 
@@ -72,6 +79,7 @@ source = pathlib.Path(sys.argv[2])
 text = source.read_text()
 text = text.replace('__IMAGE_REF__', sys.argv[3])
 text = text.replace('__IMAGE_TAG__', sys.argv[4])
+text = text.replace('__AUTOPART_EXTRA__', sys.argv[5])
 pathlib.Path(sys.argv[1]).write_text(text)
 PY
 cp "$work_dir/bluefin-unattended.ks" "$kickstart_file"
@@ -160,6 +168,39 @@ kill "$install_pid" 2>/dev/null || true
 wait "$install_pid" 2>/dev/null || true
 install_pid=""
 
+luks_evidence=""
+if [[ "$luks_enabled" == "1" ]]; then
+    # Hard assertion that the installed disk really is LUKS-encrypted, before
+    # we prove it can also be unlocked at boot.
+    if command -v qemu-nbd >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        sudo modprobe nbd max_part=8
+        sudo qemu-nbd --connect=/dev/nbd0 "$install_disk"
+        for _ in $(seq 1 10); do
+            [[ -b /dev/nbd0p1 ]] && break
+            sleep 1
+        done
+        luks_parts="$(sudo blkid -o value -s TYPE /dev/nbd0p* 2>/dev/null | grep -c 'crypto_LUKS' || true)"
+        sudo qemu-nbd --disconnect /dev/nbd0 >/dev/null
+        if [[ "$luks_parts" -lt 1 ]]; then
+            echo "LUKS mode requested but no crypto_LUKS partition found on installed disk" >&2
+            exit 1
+        fi
+        luks_evidence="crypto_LUKS-partition-present"
+        echo "Verified installed disk has ${luks_parts} crypto_LUKS partition(s)"
+    else
+        echo "qemu-nbd/sudo unavailable; skipping on-disk LUKS assertion (boot unlock still enforced)" >&2
+        luks_evidence="on-disk-check-skipped"
+    fi
+fi
+
+post_serial_socket="$work_dir/post-serial.sock"
+serial_driver_pid=""
+if [[ "$luks_enabled" == "1" ]]; then
+    post_serial_args=(-chardev "socket,id=ser0,path=${post_serial_socket},server=on,wait=off" -serial chardev:ser0)
+else
+    post_serial_args=(-serial "file:$post_install_serial")
+fi
+
 "$qemu_binary" \
     -name bluefin-e2e-postinstall \
     -machine "${qemu_machine},accel=${qemu_accel}" \
@@ -169,13 +210,61 @@ install_pid=""
     -drive file="$install_disk",format=qcow2,if=virtio,cache=none \
     -netdev user,id=net0 \
     -device virtio-net-pci,netdev=net0 \
-    -serial "file:$post_install_serial" \
+    "${post_serial_args[@]}" \
     -vga std \
     -display none \
     -monitor none \
     -qmp "unix:$post_qmp_socket,server=on,wait=off" \
     > /dev/null 2>&1 &
 post_install_pid=$!
+
+if [[ "$luks_enabled" == "1" ]]; then
+    # Answer the systemd-cryptsetup passphrase prompt on the serial console and
+    # mirror everything we see into the regular post-install serial log.
+    python3 - "$post_serial_socket" "$post_install_serial" "$luks_passphrase" <<'PY' &
+import re
+import socket
+import sys
+import time
+
+sock_path, log_path, passphrase = sys.argv[1], sys.argv[2], sys.argv[3]
+
+sock = None
+for _ in range(30):
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(sock_path)
+        break
+    except OSError:
+        time.sleep(1)
+else:
+    sys.exit(1)
+
+sock.settimeout(5)
+buffer = b''
+answered = 0
+prompt = re.compile(rb'(enter passphrase|passphrase for disk|Please enter passphrase)', re.IGNORECASE)
+with open(log_path, 'wb', buffering=0) as log:
+    deadline = time.time() + 900
+    while time.time() < deadline:
+        try:
+            chunk = sock.recv(4096)
+        except socket.timeout:
+            continue
+        except OSError:
+            break
+        if not chunk:
+            break
+        log.write(chunk)
+        buffer = (buffer + chunk)[-8192:]
+        if prompt.search(buffer) and answered < 5:
+            time.sleep(1)
+            sock.sendall(passphrase.encode() + b'\n')
+            answered += 1
+            buffer = b''
+PY
+    serial_driver_pid=$!
+fi
 
 post_install_evidence=""
 post_start=$SECONDS
@@ -194,6 +283,16 @@ done
 if [[ -z "$post_install_evidence" ]]; then
     echo "Installed system did not boot within ${post_install_timeout}s" >&2
     exit 1
+fi
+
+if [[ "$luks_enabled" == "1" ]]; then
+    # The boot marker plus a passphrase prompt in the log proves the unlock
+    # path was exercised rather than the disk being silently unencrypted.
+    if ! grep -Eqi 'passphrase' "$post_install_serial" 2>/dev/null; then
+        echo "LUKS mode: installed system booted but no passphrase prompt was observed" >&2
+        exit 1
+    fi
+    luks_evidence="${luks_evidence:+${luks_evidence},}unlock-prompt-answered-and-booted"
 fi
 
 for _ in $(seq 1 10); do
@@ -238,8 +337,12 @@ fi
 
 kill "$post_install_pid" 2>/dev/null || true
 wait "$post_install_pid" 2>/dev/null || true
+if [[ -n "$serial_driver_pid" ]]; then
+    kill "$serial_driver_pid" 2>/dev/null || true
+    wait "$serial_driver_pid" 2>/dev/null || true
+fi
 
-python3 - "$summary_file" "$iso_path" "$serial_file" "$post_install_serial" "$final_screen_png" "$install_evidence" "$post_install_evidence" <<'PY'
+python3 - "$summary_file" "$iso_path" "$serial_file" "$post_install_serial" "$final_screen_png" "$install_evidence" "$post_install_evidence" "$luks_evidence" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -251,11 +354,13 @@ post_install_serial = Path(sys.argv[4])
 image_path = Path(sys.argv[5])
 install_evidence = sys.argv[6]
 post_install_evidence = sys.argv[7]
+luks_evidence = sys.argv[8] if len(sys.argv) > 8 else ''
 summary = {
     'result': 'passed' if install_evidence and post_install_evidence else 'failed',
     'iso': str(iso_path),
     'install_evidence': install_evidence or None,
     'post_install_evidence': post_install_evidence or None,
+    'luks_evidence': luks_evidence or None,
     'serial_log': serial_path.name if serial_path.exists() else None,
     'post_install_serial_log': post_install_serial.name if post_install_serial.exists() else None,
     'final_screen_image': image_path.name if image_path.exists() else None,

--- a/tests/iso/e2e.sh
+++ b/tests/iso/e2e.sh
@@ -167,7 +167,7 @@ done
     -display none \
     -monitor none \
     -qmp "unix:$qmp_socket,server=on,wait=off" \
-    -append "${iso_kargs} console=ttyS0 rd.neednet=1 ip=dhcp inst.ks=http://10.0.2.2:${http_port}/kickstart.ks inst.text systemd.unit=anaconda.target" \
+    -append "${iso_kargs} console=ttyS0 rd.neednet=1 ip=dhcp inst.ks=http://10.0.2.2:${http_port}/kickstart.ks inst.text systemd.unit=anaconda.target systemd.journald.forward_to_console=1" \
     -no-reboot > /dev/null 2>&1 &
 install_pid=$!
 

--- a/tests/iso/e2e.sh
+++ b/tests/iso/e2e.sh
@@ -167,7 +167,7 @@ done
     -display none \
     -monitor none \
     -qmp "unix:$qmp_socket,server=on,wait=off" \
-    -append "${iso_kargs} console=ttyS0 rd.neednet=1 ip=dhcp inst.ks=http://10.0.2.2:${http_port}/kickstart.ks inst.text" \
+    -append "${iso_kargs} console=ttyS0 rd.neednet=1 ip=dhcp inst.ks=http://10.0.2.2:${http_port}/kickstart.ks inst.text systemd.unit=anaconda.target" \
     -no-reboot > /dev/null 2>&1 &
 install_pid=$!
 

--- a/tests/iso/e2e.sh
+++ b/tests/iso/e2e.sh
@@ -88,6 +88,15 @@ if [[ ! -f "$kernel_path" ]]; then
     xorriso -indev "$iso_path" -osirrox on -extract /boot/vmlinuz "$kernel_path"
 fi
 
+# The live root is found by CD label, which differs between variants
+# (stable vs LTS builders) — read it from the ISO instead of hardcoding.
+iso_label="$(xorriso -indev "$iso_path" -pvd_info 2>/dev/null \
+    | sed -n "s/^Volume Id *: *'\{0,1\}\([^']*\)'\{0,1\}[[:space:]]*$/\1/p" | head -1)"
+if [[ -z "$iso_label" ]]; then
+    iso_label="titanoboa_boot"
+fi
+echo "Using live root CDLABEL=${iso_label}"
+
 if [[ ! -f "$initrd_path" ]]; then
     xorriso -indev "$iso_path" -osirrox on -extract /boot/initramfs.img "$initrd_path"
 fi
@@ -137,7 +146,7 @@ done
     -display none \
     -monitor none \
     -qmp "unix:$qmp_socket,server=on,wait=off" \
-    -append "console=ttyS0 rd.live.image rd.live.ram rd.neednet=1 ip=dhcp root=live:CDLABEL=titanoboa_boot inst.ks=http://10.0.2.2:${http_port}/kickstart.ks inst.text" \
+    -append "console=ttyS0 rd.live.image rd.live.ram rd.neednet=1 ip=dhcp root=live:CDLABEL=${iso_label} inst.ks=http://10.0.2.2:${http_port}/kickstart.ks inst.text" \
     -no-reboot > /dev/null 2>&1 &
 install_pid=$!
 

--- a/tests/iso/e2e.sh
+++ b/tests/iso/e2e.sh
@@ -97,6 +97,27 @@ if [[ -z "$iso_label" ]]; then
 fi
 echo "Using live root CDLABEL=${iso_label}"
 
+# Boot with the ISO's own GRUB kernel arguments so the live rootfs is
+# assembled exactly as on real hardware — variants disagree about details
+# like rd.live.ram vs overlay. Fall back to the historic stable args.
+iso_kargs=""
+for cfg_path in /boot/grub2/grub.cfg /EFI/BOOT/grub.cfg /boot/grub/grub.cfg; do
+    grub_cfg="$work_dir/grub.cfg"
+    rm -f "$grub_cfg"
+    if xorriso -indev "$iso_path" -osirrox on -extract "$cfg_path" "$grub_cfg" 2>/dev/null; then
+        iso_kargs="$(awk '/^[[:space:]]*linux(efi)?[[:space:]]/{for(i=3;i<=NF;i++) printf "%s ", $i; exit}' "$grub_cfg")"
+        if [[ -n "$iso_kargs" ]]; then
+            break
+        fi
+    fi
+done
+if [[ -z "$iso_kargs" ]]; then
+    iso_kargs="root=live:CDLABEL=${iso_label} rd.live.image rd.live.ram rd.neednet=1"
+fi
+# Serial-friendly, unattended: drop splash args the GRUB entry may carry.
+iso_kargs="$(sed -E 's/(^| )(quiet|rhgb|splash)( |$)/ /g' <<<"$iso_kargs" | tr -s ' ')"
+echo "Using kernel args from ISO: ${iso_kargs}"
+
 if [[ ! -f "$initrd_path" ]]; then
     xorriso -indev "$iso_path" -osirrox on -extract /boot/initramfs.img "$initrd_path"
 fi
@@ -133,7 +154,7 @@ done
     -name bluefin-e2e \
     -machine "${qemu_machine},accel=${qemu_accel}" \
     -cpu max \
-    -m 4096 \
+    -m "${E2E_MEMORY_MB:-6144}" \
     -smp 2 \
     -drive file="$install_disk",format=qcow2,if=virtio,cache=none \
     -cdrom "$iso_path" \
@@ -146,7 +167,7 @@ done
     -display none \
     -monitor none \
     -qmp "unix:$qmp_socket,server=on,wait=off" \
-    -append "console=ttyS0 rd.live.image rd.live.ram rd.neednet=1 ip=dhcp root=live:CDLABEL=${iso_label} inst.ks=http://10.0.2.2:${http_port}/kickstart.ks inst.text" \
+    -append "${iso_kargs} console=ttyS0 rd.neednet=1 ip=dhcp inst.ks=http://10.0.2.2:${http_port}/kickstart.ks inst.text" \
     -no-reboot > /dev/null 2>&1 &
 install_pid=$!
 
@@ -214,7 +235,7 @@ fi
     -name bluefin-e2e-postinstall \
     -machine "${qemu_machine},accel=${qemu_accel}" \
     -cpu max \
-    -m 4096 \
+    -m "${E2E_MEMORY_MB:-6144}" \
     -smp 2 \
     -drive file="$install_disk",format=qcow2,if=virtio,cache=none \
     -netdev user,id=net0 \


### PR DESCRIPTION
Every scheduled ISO build on `main` (LTS, LTS-HWE, Stable, All) has failed since late July. Investigation of the failed run logs shows two independent root causes, neither of which is disk space (so this supersedes the diagnosis behind #69 — the ISOs actually build successfully):

## amd64: `Rename ISO` references a step output that no longer exists

When the **Build ISO** step in `reusable-build-iso-anaconda.yml` was rewritten from the titanoboa GitHub action to a plain `run:` script, it stopped emitting the `iso-dest` output. The **Rename ISO** step still reads `steps.build.outputs.iso-dest`, so `OUTPUT_PATH` is empty and every job dies at:

```
mv: cannot stat '': No such file or directory
```

Fix: re-emit `iso-dest` from the build step (`echo "iso-dest=$(realpath output.iso)" >> "$GITHUB_OUTPUT"`). This alone unblocks all amd64 ISO builds.

## arm64: source manifests have no arm64 entry

arm64 legs fail earlier with:

```
Error: choosing an image from manifest list docker://ghcr.io/ublue-os/bluefin:lts: no image found in image index for architecture arm64
```

That has to be fixed in the image publish pipeline (see projectbluefin/bluefin-lts#421 / #500), not here. Until the manifests carry arm64 again, the arm64 matrix legs are marked `continue-on-error` so scheduled runs go green and amd64 ISOs keep publishing.

Relates to projectbluefin/iso#69 (the disk-cleanup step there is harmless headroom but does not fix these failures — its own CI failed with the exact same two errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSjBPVDcnK71WveusaK7Nc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSjBPVDcnK71WveusaK7Nc)_